### PR TITLE
BuildProject.bat Engine plugin support

### DIFF
--- a/BuildProject.bat
+++ b/BuildProject.bat
@@ -1,30 +1,108 @@
 @echo off
 
-rem Input args: BuildName, Platform, BuildConfiguration, uproject
-
 call "%~dp0ProjectPaths.bat"
 
-rem Try to build using a project plugin first.
-set BuildWorkerBat="%~dp0%PROJECT_PATH%/Plugins/UnrealGDK/SpatialGDK/Build/Scripts/BuildWorker.bat"
-if exist %BuildWorkerBat% (
-    goto :Build
+setlocal EnableDelayedExpansion
+
+set GDKDirectory=""
+
+rem If a project plugin exists. Use this for building.
+if exist "%~dp0\%PROJECT_PATH%\Plugins\UnrealGDK" (
+    set GDKDirectory="%~dp0\%PROJECT_PATH%\Plugins\UnrealGDK\"
+    goto :BuildWorkers
 )
 
-rem If no project plugin exists, try to build using an engine plugin.
-set BuildWorkerBat="%~dp0../../Engine/Plugins/UnrealGDK/SpatialGDK/Build/Scripts/BuildWorker.bat"
-if not exist %BuildWorkerBat% (
-    echo Cannot find BuildWorker.bat! Please check you have the SpatialGDK plugin installed.
-    goto :Error
+rem If there is no project plugin. Find the engine plugin.
+
+rem Get the Unreal Engine used by this project by querying the registry for the engine association found in the .uproject.
+set UNREAL_ENGINE=""
+set UPROJECT=""
+
+rem First find the .uproject
+for /f "delims=" %%A in (' powershell -Command "Get-ChildItem %~dp0 -Depth 1 -Filter *.uproject -File | %% {$_.FullName}" ') do set UPROJECT="%%A"
+
+rem If the regex failed then it will return a string containing only a space.
+if %UPROJECT%=="" (
+    echo Error: Could not find uproject. Please make sure you have passed in the project directory correctly.
+    pause
+    exit /b 1
 )
 
-:Build
-call %BuildWorkerBat% %GAME_NAME%Server Linux Development %GAME_NAME%.uproject || goto :Error
-call %BuildWorkerBat% %GAME_NAME% Win64 Development %GAME_NAME%.uproject || goto :Error
+echo Using uproject: %UPROJECT%
+
+rem Get the Engine association from the uproject.
+for /f "delims=" %%A in (' powershell -Command "(Get-Content %UPROJECT% | ConvertFrom-Json).EngineAssociation" ') do set ENGINE_ASSOCIATION="%%A"
+
+echo Engine association for uproject is: %ENGINE_ASSOCIATION%
+
+rem If the engine association is a path then use this.
+if exist "%ENGINE_ASSOCIATION%" (
+    set UNREAL_ENGINE=%ENGINE_ASSOCIATION%
+)
+
+rem Try and use the engine association as a key in the registry to get the path to Unreal.
+if %UNREAL_ENGINE%=="" (
+    if not "%ENGINE_ASSOCIATION%"=="" (
+        rem Query the registry for the path to the Unreal Engine using the engine associtation.
+        for /f "usebackq tokens=3*" %%A in (`reg query "HKCU\Software\Epic Games\Unreal Engine\Builds" /v %ENGINE_ASSOCIATION%`) do (
+            set UNREAL_ENGINE="%%A"
+        )
+    )
+)
+
+rem If there was no engine association then we need to climb the directory path of the project to find the Engine.
+if %UNREAL_ENGINE%=="" (
+    pushd "%~dp0"
+
+    :climb_parent_directory
+    if exist Engine (
+        rem Check for the Build.version file to be sure we have found a correct Engine folder.
+        if exist "Engine\Build\Build.version" (
+            set UNREAL_ENGINE="!cd!"
+        )
+    ) else (
+        rem This checks if we are in a root directory. If so we cannot check any higher and so should error out.
+        if "%cd:~3,1%"=="" (
+            echo Error: Could not find Unreal Engine folder. Please set a project association or ensure your game project is within an Unreal Engine folder.
+            pause
+            exit /b 1
+        )
+        cd ..
+        goto :climb_parent_directory
+    )
+
+    popd
+)
+
+if %UNREAL_ENGINE%=="" (
+    echo Error: Could not find the Unreal Engine. Please associate your '.uproject' with an engine version or ensure this game project is nested within an engine build.
+    pause
+    exit /b 1
+)
+
+rem Make the relative path absolute
+pushd "%~dp0\%PROJECT_PATH%"
+cd %UNREAL_ENGINE%
+
+echo Using Unreal Engine at: %cd%
+
+set GDKDirectory="%cd%\Engine\Plugins\UnrealGDK"
+popd
+
+:BuildWorkers
+echo Building worker with GDK located at %GDKDirectory%
+echo BuildWorker: %GDKDirectory%\SpatialGDK\Build\Scripts\BuildWorker.bat
+
+pushd 
+
+call %GDKDirectory%\SpatialGDK\Build\Scripts\BuildWorker.bat %GAME_NAME%Server Linux Development "%~dp0\%PROJECT_PATH%\%GAME_NAME%.uproject" || goto :error
+call %GDKDirectory%\SpatialGDK\Build\Scripts\BuildWorker.bat %GAME_NAME% Win64 Development "%~dp0\%PROJECT_PATH%\%GAME_NAME%.uproject" || goto :error
+echo All builds succeeded.
 
 pause
 exit /b 0
 
-:Error
+:error
 echo Builds failed.
 pause
 exit /b 1

--- a/BuildProject.bat
+++ b/BuildProject.bat
@@ -1,13 +1,30 @@
 @echo off
+
+rem Input args: BuildName, Platform, BuildConfiguration, uproject
+
 call "%~dp0ProjectPaths.bat"
-call %~dp0%PROJECT_PATH%\"Plugins/UnrealGDK/SpatialGDK/Build/Scripts/BuildWorker.bat" %GAME_NAME%Server Linux Development %GAME_NAME%.uproject || goto :error
-call %~dp0%PROJECT_PATH%\"Plugins/UnrealGDK/SpatialGDK/Build/Scripts/BuildWorker.bat" %GAME_NAME% Win64 Development %GAME_NAME%.uproject || goto :error
-echo All builds succeeded.
+
+rem Try to build using a project plugin first.
+set BuildWorkerBat="%~dp0%PROJECT_PATH%/Plugins/UnrealGDK/SpatialGDK/Build/Scripts/BuildWorker.bat"
+if exist %BuildWorkerBat% (
+    goto :Build
+)
+
+rem If no project plugin exists, try to build using an engine plugin.
+set BuildWorkerBat="%~dp0../../Engine/Plugins/UnrealGDK/SpatialGDK/Build/Scripts/BuildWorker.bat"
+if not exist %BuildWorkerBat% (
+    echo Cannot find BuildWorker.bat! Please check you have the SpatialGDK plugin installed.
+    goto :Error
+)
+
+:Build
+call %BuildWorkerBat% %GAME_NAME%Server Linux Development %GAME_NAME%.uproject || goto :Error
+call %BuildWorkerBat% %GAME_NAME% Win64 Development %GAME_NAME%.uproject || goto :Error
 
 pause
 exit /b 0
 
-:error
+:Error
 echo Builds failed.
 pause
 exit /b 1

--- a/BuildProject.bat
+++ b/BuildProject.bat
@@ -4,11 +4,11 @@ call "%~dp0ProjectPaths.bat"
 
 setlocal EnableDelayedExpansion
 
-set GDKDirectory=""
+set GDK_DIRECTORY=""
 
 rem If a project plugin exists. Use this for building.
 if exist "%~dp0\%PROJECT_PATH%\Plugins\UnrealGDK" (
-    set GDKDirectory="%~dp0\%PROJECT_PATH%\Plugins\UnrealGDK\"
+    set GDK_DIRECTORY="%~dp0\%PROJECT_PATH%\Plugins\UnrealGDK\"
     goto :BuildWorkers
 )
 
@@ -21,7 +21,6 @@ set UPROJECT=""
 rem First find the .uproject
 for /f "delims=" %%A in (' powershell -Command "Get-ChildItem %~dp0 -Depth 1 -Filter *.uproject -File | %% {$_.FullName}" ') do set UPROJECT="%%A"
 
-rem If the regex failed then it will return a string containing only a space.
 if %UPROJECT%=="" (
     echo Error: Could not find uproject. Please make sure you have passed in the project directory correctly.
     pause
@@ -86,14 +85,14 @@ cd %UNREAL_ENGINE%
 
 echo Using Unreal Engine at: %cd%
 
-set GDKDirectory="%cd%\Engine\Plugins\UnrealGDK"
+set GDK_DIRECTORY="%cd%\Engine\Plugins\UnrealGDK"
 popd
 
 :BuildWorkers
-echo Building worker with GDK located at %GDKDirectory%
+echo Building worker with GDK located at %GDK_DIRECTORY%
 
-call %GDKDirectory%\SpatialGDK\Build\Scripts\BuildWorker.bat %GAME_NAME%Server Linux Development "%~dp0\%PROJECT_PATH%\%GAME_NAME%.uproject" || goto :error
-call %GDKDirectory%\SpatialGDK\Build\Scripts\BuildWorker.bat %GAME_NAME% Win64 Development "%~dp0\%PROJECT_PATH%\%GAME_NAME%.uproject" || goto :error
+call %GDK_DIRECTORY%\SpatialGDK\Build\Scripts\BuildWorker.bat %GAME_NAME%Server Linux Development "%~dp0\%PROJECT_PATH%\%GAME_NAME%.uproject" || goto :error
+call %GDK_DIRECTORY%\SpatialGDK\Build\Scripts\BuildWorker.bat %GAME_NAME% Win64 Development "%~dp0\%PROJECT_PATH%\%GAME_NAME%.uproject" || goto :error
 echo All builds succeeded.
 
 pause

--- a/BuildProject.bat
+++ b/BuildProject.bat
@@ -80,13 +80,9 @@ if %UNREAL_ENGINE%=="" (
 )
 
 rem Make the relative path absolute
-pushd "%~dp0\%PROJECT_PATH%"
 cd %UNREAL_ENGINE%
-
 echo Using Unreal Engine at: %cd%
-
 set GDK_DIRECTORY="%cd%\Engine\Plugins\UnrealGDK"
-popd
 
 :BuildWorkers
 echo Building worker with GDK located at %GDK_DIRECTORY%

--- a/BuildProject.bat
+++ b/BuildProject.bat
@@ -80,9 +80,13 @@ if %UNREAL_ENGINE%=="" (
 )
 
 rem Make the relative path absolute
+pushd "%~dp0\%PROJECT_PATH%"
 cd %UNREAL_ENGINE%
+
 echo Using Unreal Engine at: %cd%
+
 set GDK_DIRECTORY="%cd%\Engine\Plugins\UnrealGDK"
+popd
 
 :BuildWorkers
 echo Building worker with GDK located at %GDK_DIRECTORY%

--- a/BuildProject.bat
+++ b/BuildProject.bat
@@ -42,9 +42,9 @@ if exist "%ENGINE_ASSOCIATION%" (
 rem Try and use the engine association as a key in the registry to get the path to Unreal.
 if %UNREAL_ENGINE%=="" (
     if not "%ENGINE_ASSOCIATION%"=="" (
-        rem Query the registry for the path to the Unreal Engine using the engine associtation.
+        rem Query the registry for the path to the Unreal Engine using the engine association.
         for /f "usebackq tokens=3*" %%A in (`reg query "HKCU\Software\Epic Games\Unreal Engine\Builds" /v %ENGINE_ASSOCIATION%`) do (
-            set UNREAL_ENGINE="%%A"
+            set UNREAL_ENGINE="%%A %%B"
         )
     )
 )
@@ -79,12 +79,11 @@ if %UNREAL_ENGINE%=="" (
     exit /b 1
 )
 
-rem Make the relative path absolute
+rem Make the relative path absolute. Pushd to PROJECT_PATH is required as a relative path will be relative to the .uproject file.
 pushd "%~dp0\%PROJECT_PATH%"
-cd %UNREAL_ENGINE%
-
+echo Changing engine: %UNREAL_ENGINE%
+cd /d %UNREAL_ENGINE%
 echo Using Unreal Engine at: %cd%
-
 set GDK_DIRECTORY="%cd%\Engine\Plugins\UnrealGDK"
 popd
 

--- a/BuildProject.bat
+++ b/BuildProject.bat
@@ -91,9 +91,6 @@ popd
 
 :BuildWorkers
 echo Building worker with GDK located at %GDKDirectory%
-echo BuildWorker: %GDKDirectory%\SpatialGDK\Build\Scripts\BuildWorker.bat
-
-pushd 
 
 call %GDKDirectory%\SpatialGDK\Build\Scripts\BuildWorker.bat %GAME_NAME%Server Linux Development "%~dp0\%PROJECT_PATH%\%GAME_NAME%.uproject" || goto :error
 call %GDKDirectory%\SpatialGDK\Build\Scripts\BuildWorker.bat %GAME_NAME% Win64 Development "%~dp0\%PROJECT_PATH%\%GAME_NAME%.uproject" || goto :error


### PR DESCRIPTION
Update to the helper script BuildProject.bat which will allow engine plugin support by default. 
This change does not affect project plugins. The change to this script will also be added to TemplateProject for ease of use.