### PR TITLE
UNR-1768 fix launch client script

### DIFF
--- a/LaunchClient.bat
+++ b/LaunchClient.bat
@@ -1,4 +1,8 @@
 @echo off
 call "%~dp0FindEngine.bat"
 call "%~dp0ProjectPaths.bat"
-%UNREAL_ENGINE%"\Engine\Binaries\Win64\UE4Editor.exe" "%~dp0%PROJECT_PATH%\%GAME_NAME%.uproject" 127.0.0.1 -game -log -workerType UnrealClient -stdout -nowrite -unattended -nologtimes -nopause -noin -messaging -NoVerifyGC -windowed -ResX=800 -ResY=600
+
+:: Need to strip the path to engine from quotes, so that we can combine it with the path to editor executable.
+set UNREAL_ENGINE_STRIPPED_FROM_QUOTES=%UNREAL_ENGINE:~1,-1%
+
+"%UNREAL_ENGINE_STRIPPED_FROM_QUOTES%\Engine\Binaries\Win64\UE4Editor.exe" "%~dp0%PROJECT_PATH%\%GAME_NAME%.uproject" 127.0.0.1 -game -log -workerType UnrealClient -stdout -nowrite -unattended -nologtimes -nopause -noin -messaging -NoVerifyGC -windowed -ResX=800 -ResY=600


### PR DESCRIPTION
Path to Unreal Editor executable in LaunchClient.bat script resolves to` "<path_to_engine>""\Engine\Binaries\Win64\UE4Editor.exe"` due to `<path_to_engine>` also being in quotes. Therefore the command fails, as it doesn't actually call the executable. This PR strips path to engine from quotes before concatenating it with path to executable.