### PR TITLE
Remove quotes from engine path

### DIFF
--- a/LaunchClient.bat
+++ b/LaunchClient.bat
@@ -1,4 +1,4 @@
 @echo off
 call "%~dp0FindEngine.bat"
 call "%~dp0ProjectPaths.bat"
-%UNREAL_ENGINE%"\Engine\Binaries\Win64\UE4Editor.exe" "%~dp0%PROJECT_PATH%\%GAME_NAME%.uproject" 127.0.0.1 -game -log -workerType UnrealClient -stdout -nowrite -unattended -nologtimes -nopause -noin -messaging -NoVerifyGC -windowed -ResX=800 -ResY=600
+"%UNREAL_ENGINE:"=%\Engine\Binaries\Win64\UE4Editor.exe" "%~dp0%PROJECT_PATH%\%GAME_NAME%.uproject" 127.0.0.1 -game -log -workerType UnrealClient -stdout -nowrite -unattended -nologtimes -nopause -noin -messaging -NoVerifyGC -windowed -ResX=800 -ResY=600

--- a/LaunchServer.bat
+++ b/LaunchServer.bat
@@ -1,4 +1,4 @@
 @echo off
 call "%~dp0FindEngine.bat"
 call "%~dp0ProjectPaths.bat"
-%UNREAL_ENGINE%"\Engine\Binaries\Win64\UE4Editor.exe" "%~dp0%PROJECT_PATH%\%GAME_NAME%.uproject" -server -log -workerType UnrealWorker -stdout -nowrite -unattended -nologtimes -nopause -noin -messaging -SaveToUserDir -NoVerifyGC -windowed -resX=400 -resY=300
+"%UNREAL_ENGINE:"=%\Engine\Binaries\Win64\UE4Editor.exe" "%~dp0%PROJECT_PATH%\%GAME_NAME%.uproject" -server -log -workerType UnrealWorker -stdout -nowrite -unattended -nologtimes -nopause -noin -messaging -SaveToUserDir -NoVerifyGC -windowed -resX=400 -resY=300


### PR DESCRIPTION
Quotes in the path can sometimes cause issues. Removed them from the Engine Path using %UNREAL_ENGINE:"=% magic. Essentially means "Take the string and turn all '"' into empty"