### PR TITLE
Add command line cheats to set lobby and match timers

### DIFF
--- a/Game/Source/GDKShooter/Private/Game/Components/LobbyTimerComponent.cpp
+++ b/Game/Source/GDKShooter/Private/Game/Components/LobbyTimerComponent.cpp
@@ -11,6 +11,7 @@ void ULobbyTimerComponent::BeginPlay()
 	// Developer cheat so you don't have to wait for a long time before entering a match.
 	const TCHAR* CommandLine = FCommandLine::Get();
 	FParse::Value(CommandLine, TEXT("lobbytime"), DefaultTimerDuration);
+	FParse::Value(CommandLine, TEXT("lobbyminplayers"), MinimumPlayersToStartCountdown);
 #endif
 	bAutoStart = (MinimumPlayersToStartCountdown == 0);
 	Super::BeginPlay();

--- a/Game/Source/GDKShooter/Private/Game/Components/LobbyTimerComponent.cpp
+++ b/Game/Source/GDKShooter/Private/Game/Components/LobbyTimerComponent.cpp
@@ -3,9 +3,15 @@
 #include "LobbyTimerComponent.h"
 #include "GDKLogging.h"
 #include "GameFramework/Actor.h"
+#include "Misc/CommandLine.h"
 
 void ULobbyTimerComponent::BeginPlay()
 {
+#if !UE_BUILD_SHIPPING
+	// Developer cheat so you don't have to wait for a long time before entering a match.
+	const TCHAR* CommandLine = FCommandLine::Get();
+	FParse::Value(CommandLine, TEXT("lobbytime"), DefaultTimerDuration);
+#endif
 	bAutoStart = (MinimumPlayersToStartCountdown == 0);
 	Super::BeginPlay();
 }

--- a/Game/Source/GDKShooter/Private/Game/Components/MatchTimerComponent.cpp
+++ b/Game/Source/GDKShooter/Private/Game/Components/MatchTimerComponent.cpp
@@ -1,5 +1,14 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 
 #include "MatchTimerComponent.h"
+#include "Misc/CommandLine.h"
 
-
+void UMatchTimerComponent::BeginPlay()
+{
+#if !UE_BUILD_SHIPPING
+	// Developer cheat so you can run an arbitrarily long match for testing.
+	const TCHAR* CommandLine = FCommandLine::Get();
+	FParse::Value(CommandLine, TEXT("matchtime"), DefaultTimerDuration);
+#endif
+	Super::BeginPlay();
+}

--- a/Game/Source/GDKShooter/Public/Game/Components/MatchTimerComponent.h
+++ b/Game/Source/GDKShooter/Public/Game/Components/MatchTimerComponent.h
@@ -12,4 +12,6 @@ class GDKSHOOTER_API UMatchTimerComponent : public UTimerComponent
 {
 	GENERATED_BODY()
 	
+protected:
+	virtual void BeginPlay() override;
 };


### PR DESCRIPTION
For developers, quick and dirty change so we can set a short lobby timer and long match timer (or whatever one pleases). 