### PR TITLE
Disable offloading by default UNR-1886

### DIFF
--- a/Game/Config/DefaultSpatialGDKSettings.ini
+++ b/Game/Config/DefaultSpatialGDKSettings.ini
@@ -23,7 +23,7 @@ bUseDevelopmentAuthenticationFlow=False
 DevelopmentAuthenticationToken=
 DevelopmentDeploymentToConnect=
 DefaultWorkerType=(WorkerTypeName="UnrealWorker")
-bEnableOffloading=True
+bEnableOffloading=False
 ActorGroups=(("AI", (OwningWorkerType=(WorkerTypeName="AIWorker"),ActorClasses=(/Game/Characters/Turret/BP_Turret_Base.BP_Turret_Base_C,/Game/Controllers/BP_TurretController.BP_TurretController_C,/Game/Characters/Turret/BP_TurretShield.BP_TurretShield_C,/Game/Blueprints/Weapons/BP_HeavyMachineGun_ForTurret.BP_HeavyMachineGun_ForTurret_C,/Game/Blueprints/Weapons/Grenades/Turret_Rocket_Propelled.Turret_Rocket_Propelled_C,/Game/Blueprints/Weapons/BP_RocketLauncher_Continuous.BP_RocketLauncher_Continuous_C))),("CrashBot", (OwningWorkerType=(WorkerTypeName="CrashBotWorker"),ActorClasses=(/Game/Characters/BP_CrashBot.BP_CrashBot_C,/Game/Controllers/BP_CrashBotController.BP_CrashBotController_C))))
 ServerWorkerTypes=("UnrealWorker","AIWorker","CrashBotWorker")
 MaxDynamicallyAttachedSubobjectsPerClass=3


### PR DESCRIPTION
Offloading workers AIWorker / CrashWorker should not start by default in example project. Disabling offloading should have this effect.