### PR TITLE
Adapt Example Project nightly CI to use Setup.bat

### DIFF
--- a/ci/setup-and-build.ps1
+++ b/ci/setup-and-build.ps1
@@ -40,13 +40,6 @@ pushd "$exampleproject_home"
         popd
     Finish-Event "get-gdk-head-commit" "build-unreal-gdk-example-project-:windows:"
 
-    Start-Event "set-up-gdk-plugin" "build-unreal-gdk-example-project-:windows:"
-        pushd $gdk_home
-            # Invoke the GDK's setup script
-            &"$($gdk_home)\ci\setup-gdk.ps1"
-        popd
-    Finish-Event "set-up-gdk-plugin" "build-unreal-gdk-example-project-:windows:"
-
     # Use the cached engine version or set it up if it has not been cached yet.
     Start-Event "set-up-engine" "build-unreal-gdk-example-project-:windows:"
 
@@ -54,6 +47,13 @@ pushd "$exampleproject_home"
         &"$($gdk_home)\ci\get-engine.ps1" -unreal_path "$engine_directory"
 
     Finish-Event "set-up-engine" "build-unreal-gdk-example-project-:windows:"
+
+    Start-Event "set-up-gdk-plugin" "build-unreal-gdk-example-project-:windows:"
+        pushd $gdk_home
+            # Invoke the GDK's setup script
+            &"$($gdk_home)\ci\setup-gdk.ps1" -unreal_path "$engine_directory"
+        popd
+    Finish-Event "set-up-gdk-plugin" "build-unreal-gdk-example-project-:windows:"
 
 
     Start-Event "associate-uproject-with-engine" "build-unreal-gdk-example-project-:windows:"
@@ -104,14 +104,6 @@ pushd "$exampleproject_home"
                 "-run=GenerateSchemaAndSnapshots", `
                 "-MapPaths=`"/Maps/FPS-Start_Small`""
             )
-
-            # TODO (GV-29) this is also being done as part of setup.bat. We should look into calling setup.bat instead of this, but need to make sure it doesn't brake if called after setup-gdk.ps1
-            $core_gdk_schema_path = "$($gdk_home)\SpatialGDK\Extras\schema\*"
-            $schema_std_lib_path = "$($gdk_home)\SpatialGDK\Binaries\ThirdParty\Improbable\Programs\schema\*"
-            New-Item -Path "$($exampleproject_home)\spatial\schema\unreal" -Name "gdk" -ItemType Directory -Force
-            New-Item -Path "$($exampleproject_home)\spatial" -Name "\build\dependencies\schema\standard_library" -ItemType Directory -Force
-            Copy-Item "$($core_gdk_schema_path)" -Destination "$($exampleproject_home)\spatial\schema\unreal\gdk" -Force -Recurse
-            Copy-Item "$($schema_std_lib_path)" -Destination "$($exampleproject_home)\spatial\build\dependencies\schema\standard_library" -Force -Recurse
         popd
     Finish-Event "generate-schema" "build-unreal-gdk-example-project-:windows:"
 

--- a/ci/setup-and-build.ps1
+++ b/ci/setup-and-build.ps1
@@ -40,6 +40,13 @@ pushd "$exampleproject_home"
         popd
     Finish-Event "get-gdk-head-commit" "build-unreal-gdk-example-project-:windows:"
 
+    Start-Event "set-up-gdk-plugin" "build-unreal-gdk-example-project-:windows:"
+        pushd $gdk_home
+            # Invoke the GDK's setup script
+            &"$($gdk_home)\ci\setup-gdk.ps1"
+        popd
+    Finish-Event "set-up-gdk-plugin" "build-unreal-gdk-example-project-:windows:"
+
     # Use the cached engine version or set it up if it has not been cached yet.
     Start-Event "set-up-engine" "build-unreal-gdk-example-project-:windows:"
 
@@ -47,14 +54,6 @@ pushd "$exampleproject_home"
         &"$($gdk_home)\ci\get-engine.ps1" -unreal_path "$engine_directory"
 
     Finish-Event "set-up-engine" "build-unreal-gdk-example-project-:windows:"
-
-    Start-Event "set-up-gdk-plugin" "build-unreal-gdk-example-project-:windows:"
-        pushd $gdk_home
-            # Invoke the GDK's setup script
-            &"$($gdk_home)\ci\setup-gdk.ps1" -unreal_path "$engine_directory"
-        popd
-    Finish-Event "set-up-gdk-plugin" "build-unreal-gdk-example-project-:windows:"
-
 
     Start-Event "associate-uproject-with-engine" "build-unreal-gdk-example-project-:windows:"
         pushd $engine_directory


### PR DESCRIPTION
Related Unreal GDK PR: https://github.com/spatialos/UnrealGDK/pull/1422

Now uses the new setup-gdk script which in turn uses the Setup.bat script.
Also needed slight restructuring due to the changes in the setup script now symlinking the plugin into the engine.