### PR TITLE
Fix launch config by removing comma

### DIFF
--- a/spatial/default_launch.json
+++ b/spatial/default_launch.json
@@ -15,7 +15,7 @@
         {
           "name": "bridge_soft_handover_enabled",
           "value": "false"
-        },
+        }
       ],
     "snapshots": {
       "snapshot_write_period_seconds": 0


### PR DESCRIPTION
The json was invalid and couldn't be parsed, so local launches with the CLI wouldn't work. 

Use `spatial local launch` to test.