### PR TITLE
Task/unr 1905 improve slack hooks

### DIFF
--- a/.buildkite/nightly.steps.yaml
+++ b/.buildkite/nightly.steps.yaml
@@ -23,4 +23,4 @@ steps:
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
     artifact_paths:
       - "UnrealEngine/Engine/Programs/AutomationTool/Saved/Logs/*"
-      - "C:/Users/buildkite-agent/AppData/Roaming/Unreal Engine/AutomationTool/Logs/*"
+      - "C:/Users/buildkite-agent/AppData/Roaming/Unreal Engine/AutomationTool/Logs/C+b+1+unrealgdkexampleproject-nightly+UnrealEngine/*"

--- a/.buildkite/nightly.steps.yaml
+++ b/.buildkite/nightly.steps.yaml
@@ -23,3 +23,4 @@ steps:
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
     artifact_paths:
       - "UnrealEngine/Engine/Programs/AutomationTool/Saved/Logs/*"
+      - "C:/Users/buildkite-agent/AppData/Roaming/Unreal Engine/AutomationTool/Logs/*"

--- a/.buildkite/nightly.steps.yaml
+++ b/.buildkite/nightly.steps.yaml
@@ -23,4 +23,3 @@ steps:
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
     artifact_paths:
       - "UnrealEngine/Engine/Programs/AutomationTool/Saved/Logs/*"
-      - "C:/Users/buildkite-agent/AppData/Roaming/Unreal Engine/AutomationTool/Logs/C+b+1+unrealgdkexampleproject-nightly+UnrealEngine/*"

--- a/ci/deploy.ps1
+++ b/ci/deploy.ps1
@@ -90,7 +90,7 @@ pushd "spatial"
             $build_url = "$env:BUILDKITE_BUILD_URL"
             
             $json_message = [ordered]@{
-                text = $(if ((Test-Path env:BUILDKITE_NIGHTLY_BUILD) -And $env:BUILDKITE_NIGHTLY_BUILD -eq "true") {":night_with_stars: Nightly build of *Example Project*"} `
+                text = $(if ($env:BUILDKITE_NIGHTLY_BUILD -eq "true") {":night_with_stars: Nightly build of *Example Project*"} `
                         else {"*Example Project* build by $env:BUILDKITE_BUILD_CREATOR"}) + " completed succesfully."
                 attachments= @(
                         @{

--- a/ci/deploy.ps1
+++ b/ci/deploy.ps1
@@ -90,7 +90,7 @@ pushd "spatial"
             $build_url = "$env:BUILDKITE_BUILD_URL"
             
             $json_message = [ordered]@{
-                text = $(if (Test-Path env:BUILDKITE_NIGHTLY_BUILD -And $env:BUILDKITE_NIGHTLY_BUILD -eq "true") {"Nightly build of Example Project"} else {"Example Project build by $env:BUILDKITE_BUILD_CREATOR"}) + " succeeded."
+                text = $(if ((Test-Path env:BUILDKITE_NIGHTLY_BUILD) -And $env:BUILDKITE_NIGHTLY_BUILD -eq "true") {"Nightly build of Example Project"} else {"Example Project build by $env:BUILDKITE_BUILD_CREATOR"}) + " succeeded."
                 attachments= @(
                         @{
                             fallback = "Find build here: $build_url and potential deployment here: $deployment_url"

--- a/ci/deploy.ps1
+++ b/ci/deploy.ps1
@@ -88,7 +88,6 @@ pushd "spatial"
             $gdk_commit_url = "https://github.com/spatialos/UnrealGDK/commit/${gdk_commit_hash}"
             $project_commit_url = "https://github.com/spatialos/UnrealGDKExampleProject/commit/$env:BUILDKITE_COMMIT"
             $build_url = "$env:BUILDKITE_BUILD_URL"
-            
             $json_message = [ordered]@{
                 text = $(if ($env:BUILDKITE_NIGHTLY_BUILD -eq "true") {":night_with_stars: Nightly build of *Example Project*"} `
                         else {"*Example Project* build by $env:BUILDKITE_BUILD_CREATOR"}) + " completed succesfully."

--- a/ci/deploy.ps1
+++ b/ci/deploy.ps1
@@ -103,27 +103,27 @@ pushd "spatial"
                                         short = "true"
                                     }
                                     @{
-                                        title = "GDK branch"
-                                        value = "$gdk_branch_name"
+                                        title = "Example Project branch"
+                                        value = "$env:BUILDKITE_BRANCH"
                                         short = "true"
                                     }
                                     @{
-                                        title = "Example Project branch"
-                                        value = "$env:BUILDKITE_BRANCH"
+                                        title = "GDK branch"
+                                        value = "$gdk_branch_name"
                                         short = "true"
                                     }
                                 )
                             actions = @(
                                     @{
                                         type = "button"
-                                        text = ":github: View GDK commit"
-                                        url = "$gdk_commit_url"
+                                        text = ":github: View project commit"
+                                        url = "$project_commit_url"
                                         style = "primary"
                                     }
                                     @{
                                         type = "button"
-                                        text = ":github: View project commit"
-                                        url = "$project_commit_url"
+                                        text = ":github: View GDK commit"
+                                        url = "$gdk_commit_url"
                                         style = "primary"
                                     }
                                     @{

--- a/ci/deploy.ps1
+++ b/ci/deploy.ps1
@@ -151,7 +151,6 @@ pushd "spatial"
 
             Invoke-WebRequest -UseBasicParsing "$slack_webhook_url" -ContentType "application/json" -Method POST -Body "$json_request"
         }
-        
     Finish-Event "launch-deployment" "deploy-unreal-gdk-example-project-:windows:"
 
 popd

--- a/ci/deploy.ps1
+++ b/ci/deploy.ps1
@@ -78,7 +78,7 @@ pushd "spatial"
             Write-Log "Deployment will not be launched as you have passed in an argument specifying that it should not be (START_DEPLOYMENT=${launch_deployment}). Remove it to have your build launch a deployment."
         }
 
-        if ($env:BUILDKITE_BRANCH -eq "task/UNR-1905-improve-slack-hooks") {
+        if ($env:BUILDKITE_BRANCH -eq "master") {
             # Send a Slack notification with a link to the new deployment and to the build.
             # Read Slack webhook secret from the vault and extract the Slack webhook URL from it.
             $slack_webhook_secret = "$(imp-ci secrets read --environment=production --buildkite-org=improbable --secret-type=slack-webhook --secret-name=unreal-gdk-slack-web-hook)"
@@ -90,12 +90,18 @@ pushd "spatial"
             $build_url = "$env:BUILDKITE_BUILD_URL"
             
             $json_message = [ordered]@{
-                text = $(if ((Test-Path env:BUILDKITE_NIGHTLY_BUILD) -And $env:BUILDKITE_NIGHTLY_BUILD -eq "true") {"Nightly build of Example Project"} else {"Example Project build by $env:BUILDKITE_BUILD_CREATOR"}) + " succeeded."
+                text = $(if ((Test-Path env:BUILDKITE_NIGHTLY_BUILD) -And $env:BUILDKITE_NIGHTLY_BUILD -eq "true") {":night_with_stars: Nightly build of Example Project"} `
+                        else {"Example Project build by $env:BUILDKITE_BUILD_CREATOR"}) + " completed succesfully."
                 attachments= @(
                         @{
                             fallback = "Find build here: $build_url and potential deployment here: $deployment_url"
                             color = "good"
                             fields = @(
+                                    @{
+                                        title = "Build Message"
+                                        value = "$env:BUILDKITE_MESSAGE"
+                                        short = "true"
+                                    }
                                     @{
                                         title = "GDK branch"
                                         value = "$gdk_branch_name"
@@ -110,19 +116,19 @@ pushd "spatial"
                             actions = @(
                                     @{
                                         type = "button"
-                                        text = "See GDK commit"
+                                        text = ":github: View GDK commit"
                                         url = "$gdk_commit_url"
                                         style = "primary"
                                     }
                                     @{
                                         type = "button"
-                                        text = "See project commit"
+                                        text = ":github: View project commit"
                                         url = "$project_commit_url"
                                         style = "primary"
                                     }
                                     @{
                                         type = "button"
-                                        text = "See BK build"
+                                        text = ":buildkite: View build"
                                         url = "$build_url"
                                         style = "primary"
                                     }
@@ -134,7 +140,7 @@ pushd "spatial"
             if ($launch_deployment -eq "true") {
                 $deployment_button = @{
                                         type = "button"
-                                        text = "See deployment"
+                                        text = ":cloud: View deployment"
                                         url = "$deployment_url"
                                         style = "primary"
                                     }

--- a/ci/deploy.ps1
+++ b/ci/deploy.ps1
@@ -78,7 +78,7 @@ pushd "spatial"
             Write-Log "Deployment will not be launched as you have passed in an argument specifying that it should not be (START_DEPLOYMENT=${launch_deployment}). Remove it to have your build launch a deployment."
         }
 
-        if ($env:BUILDKITE_BRANCH -eq "master" -Or ((Test-Path env:BUILDKITE_SLACK_NOTIFY) -And $env:BUILDKITE_SLACK_NOTIFY -eq "true")) {
+        if ($env:BUILDKITE_BRANCH -eq "master" -Or $env:BUILDKITE_SLACK_NOTIFY -eq "true") {
             # Send a Slack notification with a link to the new deployment and to the build.
             # Read Slack webhook secret from the vault and extract the Slack webhook URL from it.
             $slack_webhook_secret = "$(imp-ci secrets read --environment=production --buildkite-org=improbable --secret-type=slack-webhook --secret-name=unreal-gdk-slack-web-hook)"

--- a/ci/deploy.ps1
+++ b/ci/deploy.ps1
@@ -89,7 +89,7 @@ pushd "spatial"
         $build_url = "$env:BUILDKITE_BUILD_URL"
         
         $json_message = [ordered]@{
-            text = $(if (Test-Path env:BUILDKITE_NIGHTLY_BUILD) {"Nightly build of Example Project"} else {"Example Project build by $env:BUILDKITE_BUILD_CREATOR"}) + " succeeded and a deployment has been launched."
+            text = (if (Test-Path env:BUILDKITE_NIGHTLY_BUILD) {"Nightly build of Example Project"} else {"Example Project build by $env:BUILDKITE_BUILD_CREATOR"}) + " succeeded and a deployment has been launched."
             attachments= @(
                     @{
                         fallback = "Find deployment here: $deployment_url and build here: $build_url"

--- a/ci/deploy.ps1
+++ b/ci/deploy.ps1
@@ -90,8 +90,8 @@ pushd "spatial"
             $build_url = "$env:BUILDKITE_BUILD_URL"
             
             $json_message = [ordered]@{
-                text = $(if ((Test-Path env:BUILDKITE_NIGHTLY_BUILD) -And $env:BUILDKITE_NIGHTLY_BUILD -eq "true") {":night_with_stars: Nightly build of Example Project"} `
-                        else {"Example Project build by $env:BUILDKITE_BUILD_CREATOR"}) + " completed succesfully."
+                text = $(if ((Test-Path env:BUILDKITE_NIGHTLY_BUILD) -And $env:BUILDKITE_NIGHTLY_BUILD -eq "true") {":night_with_stars: Nightly build of *Example Project*"} `
+                        else {"*Example Project* build by $env:BUILDKITE_BUILD_CREATOR"}) + " completed succesfully."
                 attachments= @(
                         @{
                             fallback = "Find build here: $build_url and potential deployment here: $deployment_url"

--- a/ci/deploy.ps1
+++ b/ci/deploy.ps1
@@ -138,7 +138,7 @@ pushd "spatial"
                                         url = "$deployment_url"
                                         style = "primary"
                                     }
-                $json_message["attachments"]["actions"].Add($deployment_button)
+                $json_message["attachments"][0]["actions"].Add($deployment_button)
             }
 
             $json_request = $json_message | ConvertTo-Json -Depth 10

--- a/ci/deploy.ps1
+++ b/ci/deploy.ps1
@@ -92,9 +92,9 @@ pushd "spatial"
             text = (if (Test-Path env:BUILDKITE_NIGHTLY_BUILD) {"Nightly build of Example Project"} else {"Example Project build by $env:BUILDKITE_BUILD_CREATOR"}) + " succeeded and a deployment has been launched."
             attachments= @(
                     @{
-                        fallback = "Find deployment here: $deployment_url and build here: $build_url"
+                        fallback = "Find build here: $build_url and potential deployment here: $deployment_url"
                         color = "good"
-                        fields= @(
+                        fields = @(
                                 @{
                                     title = "GDK branch"
                                     value = "$gdk_branch_name"
@@ -106,7 +106,7 @@ pushd "spatial"
                                     short = "true"
                                 }
                             )
-                        actions= @(
+                        actions = @(
                                 @{
                                     type = "button"
                                     text = "See GDK commit"
@@ -121,12 +121,6 @@ pushd "spatial"
                                 }
                                 @{
                                     type = "button"
-                                    text = "See deployment"
-                                    url = "$deployment_url"
-                                    style = "primary"
-                                }
-                                @{
-                                    type = "button"
                                     text = "See BK build"
                                     url = "$build_url"
                                     style = "primary"
@@ -135,6 +129,16 @@ pushd "spatial"
                     }
                 )
             }
+        
+        if ($launch_deployment -eq "true") {
+            $deployment_button = @{
+                                    type = "button"
+                                    text = "See deployment"
+                                    url = "$deployment_url"
+                                    style = "primary"
+                                }
+            $json_message["attachments"]["actions"].Add($deployment_button)
+        }
 
         $json_request = $json_message | ConvertTo-Json -Depth 10
 

--- a/ci/deploy.ps1
+++ b/ci/deploy.ps1
@@ -78,7 +78,7 @@ pushd "spatial"
             Write-Log "Deployment will not be launched as you have passed in an argument specifying that it should not be (START_DEPLOYMENT=${launch_deployment}). Remove it to have your build launch a deployment."
         }
 
-        if ($env:BUILDKITE_BRANCH -eq "master") {
+        if ($env:BUILDKITE_BRANCH -eq "task/UNR-1905-improve-slack-hooks") {
             # Send a Slack notification with a link to the new deployment and to the build.
             # Read Slack webhook secret from the vault and extract the Slack webhook URL from it.
             $slack_webhook_secret = "$(imp-ci secrets read --environment=production --buildkite-org=improbable --secret-type=slack-webhook --secret-name=unreal-gdk-slack-web-hook)"

--- a/ci/deploy.ps1
+++ b/ci/deploy.ps1
@@ -80,11 +80,12 @@ pushd "spatial"
             $slack_webhook_url = $slack_webhook_secret | ConvertFrom-Json | %{$_.url}
 
             $deployment_url = "https://console.improbable.io/projects/${project_name}/deployments/${deployment_name}/overview"
-            $gdk_commit_url = "https://github.com/spatialos/UnrealGDK/tree/${gdk_commit_hash}"
+            $gdk_commit_url = "https://github.com/spatialos/UnrealGDK/commit/${gdk_commit_hash}"
+            $project_commit_url = "https://github.com/spatialos/UnrealGDKExampleProject/commit/$env:BUILDKITE_COMMIT"
             $build_url = "$env:BUILDKITE_BUILD_URL"
 
             $json_message = [ordered]@{
-                text = "Example Project build created by $env:BUILDKITE_BUILD_CREATOR succeeded and a deployment has been launched."
+                text = $(if (Test-Path env:BUILDKITE_NIGHTLY_BUILD) {"Nightly build of Example Project"} else {"Example Project build by $env:BUILDKITE_BUILD_CREATOR"}) + " succeeded and a deployment has been launched."}
                 attachments= @(
                         @{
                             fallback = "Find deployment here: $deployment_url and build here: $build_url"
@@ -104,19 +105,25 @@ pushd "spatial"
                             actions= @(
                                     @{
                                         type = "button"
-                                        text = "Take me to the deployment"
-                                        url = "$deployment_url"
-                                        style = "primary"
-                                    }
-                                    @{
-                                        type = "button"
-                                        text = "Take me to the GDK commit"
+                                        text = "See GDK commit"
                                         url = "$gdk_commit_url"
                                         style = "primary"
                                     }
                                     @{
                                         type = "button"
-                                        text = "Take me to the build"
+                                        text = "See project commit"
+                                        url = "$project_commit_url"
+                                        style = "primary"
+                                    }
+                                    @{
+                                        type = "button"
+                                        text = "See deployment"
+                                        url = "$deployment_url"
+                                        style = "primary"
+                                    }
+                                    @{
+                                        type = "button"
+                                        text = "See BK build"
                                         url = "$build_url"
                                         style = "primary"
                                     }

--- a/ci/deploy.ps1
+++ b/ci/deploy.ps1
@@ -78,7 +78,7 @@ pushd "spatial"
             Write-Log "Deployment will not be launched as you have passed in an argument specifying that it should not be (START_DEPLOYMENT=${launch_deployment}). Remove it to have your build launch a deployment."
         }
 
-        if ($env:BUILDKITE_BRANCH -eq "master") {
+        if ($env:BUILDKITE_BRANCH -eq "master" -Or ((Test-Path env:BUILDKITE_SLACK_NOTIFY) -And $env:BUILDKITE_SLACK_NOTIFY -eq "true")) {
             # Send a Slack notification with a link to the new deployment and to the build.
             # Read Slack webhook secret from the vault and extract the Slack webhook URL from it.
             $slack_webhook_secret = "$(imp-ci secrets read --environment=production --buildkite-org=improbable --secret-type=slack-webhook --secret-name=unreal-gdk-slack-web-hook)"

--- a/ci/deploy.ps1
+++ b/ci/deploy.ps1
@@ -77,7 +77,7 @@ pushd "spatial"
             Write-Log "Deployment will not be launched as you have passed in an argument specifying that it should not be (START_DEPLOYMENT=${launch_deployment}). Remove it to have your build launch a deployment."
         }
 
-        if ($env:BUILDKITE_BRANCH -eq "master" -Or $env:BUILDKITE_SLACK_NOTIFY -eq "true") {
+        if ($env:BUILDKITE_BRANCH -eq "master" -or $env:BUILDKITE_SLACK_NOTIFY -eq "true") {
             # Send a Slack notification with a link to the new deployment and to the build.
             # Read Slack webhook secret from the vault and extract the Slack webhook URL from it.
             $slack_webhook_secret = "$(imp-ci secrets read --environment=production --buildkite-org=improbable --secret-type=slack-webhook --secret-name=unreal-gdk-slack-web-hook)"

--- a/ci/deploy.ps1
+++ b/ci/deploy.ps1
@@ -74,7 +74,7 @@ pushd "spatial"
                 Throw "Deployment launch failed"
             }
         }
-        else {
+        } else {
             Write-Log "Deployment will not be launched as you have passed in an argument specifying that it should not be (START_DEPLOYMENT=${launch_deployment}). Remove it to have your build launch a deployment."
         }
 

--- a/ci/deploy.ps1
+++ b/ci/deploy.ps1
@@ -73,7 +73,6 @@ pushd "spatial"
                 Write-Log "Failed to launch a Spatial cloud deployment. Error: $($launch_deployment_process.ExitCode)"
                 Throw "Deployment launch failed"
             }
-        }
         } else {
             Write-Log "Deployment will not be launched as you have passed in an argument specifying that it should not be (START_DEPLOYMENT=${launch_deployment}). Remove it to have your build launch a deployment."
         }

--- a/ci/deploy.ps1
+++ b/ci/deploy.ps1
@@ -85,7 +85,7 @@ pushd "spatial"
             $build_url = "$env:BUILDKITE_BUILD_URL"
 
             $json_message = [ordered]@{
-                text = $(if (Test-Path env:BUILDKITE_NIGHTLY_BUILD) {"Nightly build of Example Project"} else {"Example Project build by $env:BUILDKITE_BUILD_CREATOR"}) + " succeeded and a deployment has been launched."}
+                text = $(if (Test-Path env:BUILDKITE_NIGHTLY_BUILD) {"Nightly build of Example Project"} else {"Example Project build by $env:BUILDKITE_BUILD_CREATOR"}) + " succeeded and a deployment has been launched."
                 attachments= @(
                         @{
                             fallback = "Find deployment here: $deployment_url and build here: $build_url"

--- a/ci/deploy.ps1
+++ b/ci/deploy.ps1
@@ -79,6 +79,14 @@ pushd "spatial"
 
         if ($env:BUILDKITE_BRANCH -eq "master" -or $env:BUILDKITE_SLACK_NOTIFY -eq "true") {
             # Send a Slack notification with a link to the new deployment and to the build.
+
+            # Build Slack text
+            if ($env:BUILDKITE_NIGHTLY_BUILD -eq "true") {
+                $slack_text = ":night_with_stars: Nightly build of *Example Project* succeeded."
+            } else {
+                $slack_text = "*Example Project* build by $env:BUILDKITE_BUILD_CREATOR succeeded."
+            }
+
             # Read Slack webhook secret from the vault and extract the Slack webhook URL from it.
             $slack_webhook_secret = "$(imp-ci secrets read --environment=production --buildkite-org=improbable --secret-type=slack-webhook --secret-name=unreal-gdk-slack-web-hook)"
             $slack_webhook_url = $slack_webhook_secret | ConvertFrom-Json | %{$_.url}
@@ -88,8 +96,7 @@ pushd "spatial"
             $project_commit_url = "https://github.com/spatialos/UnrealGDKExampleProject/commit/$env:BUILDKITE_COMMIT"
             $build_url = "$env:BUILDKITE_BUILD_URL"
             $json_message = [ordered]@{
-                text = $(if ($env:BUILDKITE_NIGHTLY_BUILD -eq "true") {":night_with_stars: Nightly build of *Example Project*"} `
-                        else {"*Example Project* build by $env:BUILDKITE_BUILD_CREATOR"}) + " completed succesfully."
+                text = "$slack_text"
                 attachments= @(
                         @{
                             fallback = "Find build here: $build_url and potential deployment here: $deployment_url"

--- a/ci/deploy.ps1
+++ b/ci/deploy.ps1
@@ -90,7 +90,7 @@ pushd "spatial"
             $build_url = "$env:BUILDKITE_BUILD_URL"
             
             $json_message = [ordered]@{
-                text = $(if (Test-Path env:BUILDKITE_NIGHTLY_BUILD) {"Nightly build of Example Project"} else {"Example Project build by $env:BUILDKITE_BUILD_CREATOR"}) + " succeeded and a deployment has been launched."
+                text = $(if (Test-Path env:BUILDKITE_NIGHTLY_BUILD) {"Nightly build of Example Project"} else {"Example Project build by $env:BUILDKITE_BUILD_CREATOR"}) + " succeeded (and a deployment may have been launched)."
                 attachments= @(
                         @{
                             fallback = "Find build here: $build_url and potential deployment here: $deployment_url"
@@ -140,11 +140,11 @@ pushd "spatial"
                                     }
                 $json_message["attachments"]["actions"].Add($deployment_button)
             }
+
+            $json_request = $json_message | ConvertTo-Json -Depth 10
+
+            Invoke-WebRequest -UseBasicParsing "$slack_webhook_url" -ContentType "application/json" -Method POST -Body "$json_request"
         }
-
-        $json_request = $json_message | ConvertTo-Json -Depth 10
-
-        Invoke-WebRequest -UseBasicParsing "$slack_webhook_url" -ContentType "application/json" -Method POST -Body "$json_request"
         
     Finish-Event "launch-deployment" "deploy-unreal-gdk-example-project-:windows:"
 

--- a/ci/deploy.ps1
+++ b/ci/deploy.ps1
@@ -90,7 +90,7 @@ pushd "spatial"
             $build_url = "$env:BUILDKITE_BUILD_URL"
             
             $json_message = [ordered]@{
-                text = $(if (Test-Path env:BUILDKITE_NIGHTLY_BUILD) {"Nightly build of Example Project"} else {"Example Project build by $env:BUILDKITE_BUILD_CREATOR"}) + " succeeded (and a deployment may have been launched)."
+                text = $(if (Test-Path env:BUILDKITE_NIGHTLY_BUILD -And $env:BUILDKITE_NIGHTLY_BUILD -eq "true") {"Nightly build of Example Project"} else {"Example Project build by $env:BUILDKITE_BUILD_CREATOR"}) + " succeeded."
                 attachments= @(
                         @{
                             fallback = "Find build here: $build_url and potential deployment here: $deployment_url"
@@ -138,7 +138,7 @@ pushd "spatial"
                                         url = "$deployment_url"
                                         style = "primary"
                                     }
-                $json_message["attachments"][0]["actions"].Add($deployment_button)
+                $json_message["attachments"][0]["actions"] += ($deployment_button)
             }
 
             $json_request = $json_message | ConvertTo-Json -Depth 10

--- a/ci/deploy.ps1
+++ b/ci/deploy.ps1
@@ -116,19 +116,19 @@ pushd "spatial"
                             actions = @(
                                     @{
                                         type = "button"
-                                        text = ":github: View project commit"
+                                        text = ":github: Project commit"
                                         url = "$project_commit_url"
                                         style = "primary"
                                     }
                                     @{
                                         type = "button"
-                                        text = ":github: View GDK commit"
+                                        text = ":github: GDK commit"
                                         url = "$gdk_commit_url"
                                         style = "primary"
                                     }
                                     @{
                                         type = "button"
-                                        text = ":buildkite: View build"
+                                        text = ":buildkite: BK build"
                                         url = "$build_url"
                                         style = "primary"
                                     }


### PR DESCRIPTION
This change makes sure that a Slack notification is sent regardless of whether a deployment is started or not. The style and info of the Slack message itself has also been updated.

**Testing**
The Buildkite builds corresponding to this branch are green (https://buildkite.com/improbable/unrealgdkexampleproject-nightly/builds?branch=task%2FUNR-1905-improve-slack-hooks). The new messages can be seen in the `#unreal-gdk-builds` channel

**Documentation**
This change is not public-facing and has not been documented outside of its associated code.

**QA**
Create a new build of this branch on Buildkite and add the following to the "Environment Variables" form: `BUILDKITE_SLACK_NOTIFY=true`

**Reviewers**
@improbable-valentyn @mattyoung-improbable