### PR TITLE
Force ANSI allocator for iOS

### DIFF
--- a/Game/Source/GDKShooter.Target.cs
+++ b/Game/Source/GDKShooter.Target.cs
@@ -9,5 +9,10 @@ public class GDKShooterTarget : TargetRules
 	{
 		Type = TargetType.Game;
 		ExtraModuleNames.Add("GDKShooter");
+
+		if (Target.Platform == UnrealTargetPlatform.IOS)
+		{
+			GlobalDefinitions.Add("FORCE_ANSI_ALLOCATOR=1");
+		}
 	}
 }


### PR DESCRIPTION
This is needed to ensure that the correct allocator is used during runtime. If this is not set, it can lead to memory corruption and very misleading error messages like a pointer being freed multiple times. For the Unreal GDK this seems to always lead to a memory corruption during the `ConnectAsync` of the Worker SDK therefore it is necessary to have this set.