### PR TITLE
Truncate long build messages in Slack notifications

### DIFF
--- a/ci/deploy.ps1
+++ b/ci/deploy.ps1
@@ -104,7 +104,7 @@ pushd "spatial"
                             fields = @(
                                     @{
                                         title = "Build Message"
-                                        value = "$env:BUILDKITE_MESSAGE"
+                                        value = "$env:BUILDKITE_MESSAGE".Substring(0, 64)
                                         short = "true"
                                     }
                                     @{


### PR DESCRIPTION
Currently the full build message is printed in Slack notifications of ExampleProject builds, which may be the full commit message. This is a tiny change that prevents walls of text in the #unreal-gdk-builds channel.