### PR TITLE
v4-2019-11-07-bk3700-fbffad576b9676d7

### DIFF
--- a/.buildkite/nightly.steps.yaml
+++ b/.buildkite/nightly.steps.yaml
@@ -7,7 +7,7 @@ common: &common
     - "permission_set=builder"
     - "platform=windows"
     - "scaler_version=2"
-    - "queue=${CI_WINDOWS_BUILDER_QUEUE:-v3-1572610922-3d03d5c2f13b7fa4-------z}" # Has FASTbuild disabled
+    - "queue=${CI_WINDOWS_BUILDER_QUEUE:-v4-2019-11-07-bk3700-fbffad576b9676d7}" # Has FASTbuild disabled
   timeout_in_minutes: 60 # TODO(ENG-548): reduce timeout once agent-cold-start is optimised.
   retry:
     automatic:


### PR DESCRIPTION
Due to recent changes in Buildkite, scheduled builds no longer have an associated user. This causes authorization failure and thus failed builds on BK. A prior PR by the EF team fixed this for "root" scheduled builds, but authorization issues persisted for builds triggered by scheduled builds (e.g. https://buildkite.com/improbable/unrealgdkexampleproject-nightly/builds/159). With this PR we would be using a new queue that incorporates a recent fix for this problem (https://github.com/improbable/platform/pull/15695#issuecomment-551026570).

To test the change, a separate branch of the UnrealGDK repo was created that triggers a build of this UnrealGDKExampleProject branch during its BK steps. A scheduled build of the UnrealGDK branch was created:
https://buildkite.com/improbable/unrealgdk-premerge/builds/6659
This scheduled build triggered a build of this branch, which now succeeds:
https://buildkite.com/improbable/unrealgdkexampleproject-nightly/builds/166