### PR TITLE
[UNR-2731] Disable example project CI on 4.22

### DIFF
--- a/.buildkite/nightly.steps.yaml
+++ b/.buildkite/nightly.steps.yaml
@@ -38,6 +38,7 @@ steps:
       - "chmod -R +rwx ci"
       - "ci/generate-pipeline-steps.sh"
     env:
+      MAXIMUM_ENGINE_VERSIONS: "${MAXIMUM_ENGINE_VERSIONS:-1}"
       ENGINE_VERSION: "${ENGINE_VERSION}"
     <<: *script_runner
 

--- a/.buildkite/nightly.steps.yaml
+++ b/.buildkite/nightly.steps.yaml
@@ -38,7 +38,6 @@ steps:
       - "chmod -R +rwx ci"
       - "ci/generate-pipeline-steps.sh"
     env:
-      MAXIMUM_ENGINE_VERSIONS: "${MAXIMUM_ENGINE_VERSIONS:-1}"
       ENGINE_VERSION: "${ENGINE_VERSION}"
     <<: *script_runner
 

--- a/ci/generate-pipeline-steps.sh
+++ b/ci/generate-pipeline-steps.sh
@@ -21,13 +21,13 @@ done
 # The steps are based on the template in nightly.template.steps.yaml.
 
 # Default to only testing the first version listed in the unreal-engine.version file
-MAXIMUM_ENGINE_VERSIONS_LOCAL=${MAXIMUM_ENGINE_VERSIONS:-1}
+MAXIMUM_ENGINE_VERSION_COUNT_LOCAL=${MAXIMUM_ENGINE_VERSION_COUNT:-1}
 if [ -z "${ENGINE_VERSION}" ]; then 
-    echo "Generating build steps for the first $MAXIMUM_ENGINE_VERSIONS_LOCAL engine versions listed in unreal-engine.version"
+    echo "Generating build steps for the first $MAXIMUM_ENGINE_VERSION_COUNT_LOCAL engine versions listed in unreal-engine.version"
     STEP_NUMBER=1
     IFS=$'\n'
     for commit_hash in $(cat < ci/unreal-engine.version); do
-        if ((STEP_NUMBER > MAXIMUM_ENGINE_VERSIONS_LOCAL)); then
+        if ((STEP_NUMBER > MAXIMUM_ENGINE_VERSION_COUNT_LOCAL)); then
             break
         fi
         REPLACE_STRING="s|ENGINE_COMMIT_HASH_PLACEHOLDER|$commit_hash|g; s|STEP_NUMBER_PLACEHOLDER|$STEP_NUMBER|g"

--- a/ci/generate-pipeline-steps.sh
+++ b/ci/generate-pipeline-steps.sh
@@ -20,7 +20,8 @@ done
 # We retrieve these engine versions from the unreal-engine.version file in the UnrealGDK repository.
 # The steps are based on the template in nightly.template.steps.yaml.
 
-MAXIMUM_ENGINE_VERSIONS_LOCAL=${MAXIMUM_ENGINE_VERSIONS:-10}
+# Default to only testing the first version listed in the unreal-engine.version file
+MAXIMUM_ENGINE_VERSIONS_LOCAL=${MAXIMUM_ENGINE_VERSIONS:-1}
 if [ -z "${ENGINE_VERSION}" ]; then 
     echo "Generating build steps for the first $MAXIMUM_ENGINE_VERSIONS_LOCAL engine versions listed in unreal-engine.version"
     STEP_NUMBER=1

--- a/ci/generate-pipeline-steps.sh
+++ b/ci/generate-pipeline-steps.sh
@@ -20,11 +20,15 @@ done
 # We retrieve these engine versions from the unreal-engine.version file in the UnrealGDK repository.
 # The steps are based on the template in nightly.template.steps.yaml.
 
+MAXIMUM_ENGINE_VERSIONS_LOCAL=${MAXIMUM_ENGINE_VERSIONS:-10}
 if [ -z "${ENGINE_VERSION}" ]; then 
-    echo "Generating build steps for each engine version listed in unreal-engine.version"
+    echo "Generating build steps for the first $MAXIMUM_ENGINE_VERSIONS_LOCAL engine versions listed in unreal-engine.version"
     STEP_NUMBER=1
     IFS=$'\n'
     for commit_hash in $(cat < ci/unreal-engine.version); do
+        if ((STEP_NUMBER > MAXIMUM_ENGINE_VERSIONS_LOCAL)); then
+            break
+        fi
         REPLACE_STRING="s|ENGINE_COMMIT_HASH_PLACEHOLDER|$commit_hash|g; s|STEP_NUMBER_PLACEHOLDER|$STEP_NUMBER|g"
         sed $REPLACE_STRING ci/nightly.template.steps.yaml | buildkite-agent pipeline upload
         STEP_NUMBER=$((STEP_NUMBER+1))

--- a/ci/generate-pipeline-steps.sh
+++ b/ci/generate-pipeline-steps.sh
@@ -21,9 +21,9 @@ done
 # The steps are based on the template in nightly.template.steps.yaml.
 
 # Default to only testing the first version listed in the unreal-engine.version file
-MAXIMUM_ENGINE_VERSION_COUNT_LOCAL=${MAXIMUM_ENGINE_VERSION_COUNT:-1}
+MAXIMUM_ENGINE_VERSION_COUNT_LOCAL="${MAXIMUM_ENGINE_VERSION_COUNT:-1}"
 if [ -z "${ENGINE_VERSION}" ]; then 
-    echo "Generating build steps for the first $MAXIMUM_ENGINE_VERSION_COUNT_LOCAL engine versions listed in unreal-engine.version"
+    echo "Generating build steps for the first ${MAXIMUM_ENGINE_VERSION_COUNT_LOCAL} engine versions listed in unreal-engine.version"
     STEP_NUMBER=1
     IFS=$'\n'
     for commit_hash in $(cat < ci/unreal-engine.version); do


### PR DESCRIPTION
As per discussion, we do not support the example project on 4.22 anymore.