### PR TITLE
Update the ExampleProject to use the new ConnectionManager flow

### DIFF
--- a/Game/Config/DefaultSpatialGDKSettings.ini
+++ b/Game/Config/DefaultSpatialGDKSettings.ini
@@ -45,4 +45,3 @@ UdpServerUpstreamUpdateIntervalMS=1
 UdpServerDownstreamUpdateIntervalMS=1
 UdpClientUpstreamUpdateIntervalMS=1
 UdpClientDownstreamUpdateIntervalMS=1
-

--- a/Game/Config/DefaultSpatialGDKSettings.ini
+++ b/Game/Config/DefaultSpatialGDKSettings.ini
@@ -46,4 +46,3 @@ UdpServerDownstreamUpdateIntervalMS=1
 UdpClientUpstreamUpdateIntervalMS=1
 UdpClientDownstreamUpdateIntervalMS=1
 
-

--- a/Game/Source/GDKShooter/Public/Deployments/DeploymentsPlayerController.h
+++ b/Game/Source/GDKShooter/Public/Deployments/DeploymentsPlayerController.h
@@ -9,7 +9,7 @@
 
 #include "DeploymentsPlayerController.generated.h"
 
-class USpatialWorkerConnection;
+class USpatialConnectionManager;
 
 USTRUCT(BlueprintType)
 struct FDeploymentInfo {
@@ -54,7 +54,7 @@ public:
 	const char * LatestPITokenData;
 
 	FTimerHandle QueryDeploymentsTimer;
-	USpatialWorkerConnection* SpatialWorkerConnection = nullptr;
+	USpatialConnectionManager* SpatialConnectionManager = nullptr;
 
 	UFUNCTION(BlueprintCallable)
 		void JoinDeployment(const FString& LoginToken);


### PR DESCRIPTION
https://github.com/spatialos/UnrealGDK/pull/1822 changed the Connection flow to separate out the management and establishment of the connection from the actually pipe of the connection to SpatialOS. This updates the ExampleProject to use that new flow.