### PR TITLE
UNR-2965 Remove rename of FBuild.exe

### DIFF
--- a/ci/setup-and-build.ps1
+++ b/ci/setup-and-build.ps1
@@ -138,10 +138,6 @@ pushd "$exampleproject_home"
     Finish-Event "build-linux-worker" "build-unreal-gdk-example-project-:windows:"
 
     Start-Event "build-android-client" "build-unreal-gdk-example-project-:windows:"
-        # Disable Fastbuild by renaming the executable
-        # TODO: UNR-2965 will make this rename unnecessary
-        Rename-Item -Path "C:\Program Files\fastbuild\FBuild.exe" -NewName "FBuild.tmp"
-
         $unreal_uat_path = "${exampleproject_home}\UnrealEngine\Engine\Build\BatchFiles\RunUAT.bat"
         $build_server_proc = Start-Process -PassThru -NoNewWindow -FilePath $unreal_uat_path -ArgumentList @(`
             "-ScriptsForProject=$($exampleproject_home)/Game/GDKShooter.uproject", `
@@ -168,9 +164,6 @@ pushd "$exampleproject_home"
 
         $build_server_handle = $build_server_proc.Handle
         Wait-Process -Id (Get-Process -InputObject $build_server_proc).id
-
-        # Rename the FBuild.tmp back to FBuild.exe clean this up when UNR-2965 is complete
-        Rename-Item -Path "C:\Program Files\fastbuild\FBuild.tmp" -NewName "FBuild.exe"
 
         if ($build_server_proc.ExitCode -ne 0) {
             Write-Log "Failed to build Android Development Client. Error: $($build_server_proc.ExitCode)"


### PR DESCRIPTION
Remove the rename step of FBuild.exe when building Android now that the ability to enable/disable FASTBuild per platform is merged.

This is a cleanup of tech-debt.

Successful build: https://buildkite.com/improbable/unrealgdkexampleproject-nightly/builds/631#9874025d-cc6b-4ca6-ad17-d9a19fc239bc


