### PR TITLE
[CHINF-886][MS] Fixing a crash caused by the merge into release related to the jira issue.

### DIFF
--- a/Game/Source/GDKShooter/Private/Deployments/DeploymentsPlayerController.cpp
+++ b/Game/Source/GDKShooter/Private/Deployments/DeploymentsPlayerController.cpp
@@ -28,7 +28,7 @@ void ADeploymentsPlayerController::BeginPlay()
 		return true;
 	});
 	
-	SpatialWorkerConnection->Connect(true);
+	SpatialWorkerConnection->Connect(true, 0);
 }
 
 void ADeploymentsPlayerController::EndPlay(const EEndPlayReason::Type Reason)


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Previously we got the PlayInEditorID inside ConnectToReceptionist by trying to get the NetDriver and take it off that. Issue with that is that the Example project was making the SpatialWorkerConnection->Connect call before PendingNetGame was set resulting in a crash.

USpatialNetDriver* USpatialWorkerConnection::GetSpatialNetDriverChecked() const
{
	UNetDriver* NetDriver = GameInstance->GetWorld()->GetNetDriver();

	// On the client, the world might not be completely set up.
	// in this case we can use the PendingNetGame to get the NetDriver
	if (NetDriver == nullptr)
	{
		NetDriver = GameInstance->GetWorldContext()->**PendingNetGame**->GetNetDriver();
	}

	USpatialNetDriver* SpatialNetDriver = Cast<USpatialNetDriver>(NetDriver);
	checkf(SpatialNetDriver, TEXT("SpatialNetDriver was invalid while accessing SpatialNetDriver!"));
	return SpatialNetDriver;
}