### PR TITLE
[UNR-3044][MS] Fixing crash when clicking cancel button

### DIFF
--- a/Game/Source/GDKShooter/Private/Deployments/DeploymentsPlayerController.cpp
+++ b/Game/Source/GDKShooter/Private/Deployments/DeploymentsPlayerController.cpp
@@ -4,6 +4,7 @@
 
 #include "SpatialGameInstance.h"
 #include "TimerManager.h"
+#include "SpatialGDKSettings.h"
 #include "SpatialWorkerConnection.h"
 
 #include "GDKLogging.h"
@@ -18,6 +19,12 @@ void ADeploymentsPlayerController::BeginPlay()
 	USpatialGameInstance* SpatialGameInstance = GetGameInstance<USpatialGameInstance>();
 	SpatialWorkerConnection = SpatialGameInstance->GetSpatialWorkerConnection();
 
+	if (SpatialWorkerConnection == nullptr)
+	{
+		// We might not be using spatial networking in which case SpatialWorkerConnection will not exist so we should just return
+		return;
+	}
+
 	FString SpatialWorkerType = SpatialGameInstance->GetSpatialWorkerType().ToString();
 	SpatialWorkerConnection->RegisterOnLoginTokensCallback([this](const Worker_Alpha_LoginTokensResponse* Deployments){
 		Populate(Deployments);
@@ -28,7 +35,10 @@ void ADeploymentsPlayerController::BeginPlay()
 		return true;
 	});
 	
-	SpatialWorkerConnection->Connect(true, 0);
+	if (GetDefault<USpatialGDKSettings>()->bUseDevelopmentAuthenticationFlow)
+	{
+		SpatialWorkerConnection->Connect(true, 0);
+	}
 }
 
 void ADeploymentsPlayerController::EndPlay(const EEndPlayReason::Type Reason)

--- a/Game/Source/GDKShooter/Private/UI/GDKWidget.cpp
+++ b/Game/Source/GDKShooter/Private/UI/GDKWidget.cpp
@@ -4,6 +4,7 @@
 #include "Components/ControllerEventsComponent.h"
 #include "Components/GDKMovementComponent.h"
 #include "Components/HealthComponent.h"
+#include "EngineClasses/SpatialGameInstance.h"
 #include "Game/Components/LobbyTimerComponent.h"
 #include "Game/Components/MatchTimerComponent.h"
 #include "Game/Components/PlayerCountingComponent.h"
@@ -105,6 +106,11 @@ void UGDKWidget::LeaveGame(const FString& TargetMap)
 
 	FURL TravelURL;
 	TravelURL.Map = *TargetMap;
+
+	if (USpatialGameInstance* GameInstance = Cast<USpatialGameInstance>(GetGameInstance()))
+	{
+		GameInstance->GetSpatialWorkerConnection()->DestroyConnection();
+	}
 
 	GetOwningPlayer()->ClientTravel(TravelURL.ToString(), TRAVEL_Absolute, false /*bSeamless*/);
 


### PR DESCRIPTION
The developmentplayercontroller BeginPlay calls ConnectionManager->Connect. We only need to do this if we are using a dev auth token. Additionally we need to disconnect from the deployment when we click the cancel button so that when we do that connect from developmentplayercontroller we don't actually connect and instead do some funky funky logic.