### PR TITLE
[UNR-3194][MS] Adding back cross server pawn.

### DIFF
--- a/Game/Config/DefaultEngine.ini
+++ b/Game/Config/DefaultEngine.ini
@@ -40,7 +40,6 @@ MaximumLoopIterationCount=1000000
 [/Script/SpatialGDK.SpatialNetDriver]
 NetConnectionClassName="/Script/SpatialGDK.SpatialNetConnection"
 ActorReplicationRateLimit=30
-bPreventAutoConnectWithCommandLineArgs=True
 
 [Core.Log]
 LogSpatialOSActorChannel=Log
@@ -48,6 +47,9 @@ LogSpatialOSActorChannel=Log
 [/Script/HardwareTargeting.HardwareTargetingSettings]
 TargetedHardwareClass=Desktop
 DefaultGraphicsPerformance=Maximum
+
+[/Script/SpatialGDK.SpatialGameInstance]
+bPreventAutoConnectWithLocator=False
 
 [/Script/NavigationSystem.NavigationSystemV1]
 bAllowClientSideNavigation=True

--- a/Game/Config/DefaultEngine.ini
+++ b/Game/Config/DefaultEngine.ini
@@ -40,6 +40,7 @@ MaximumLoopIterationCount=1000000
 [/Script/SpatialGDK.SpatialNetDriver]
 NetConnectionClassName="/Script/SpatialGDK.SpatialNetConnection"
 ActorReplicationRateLimit=30
+bPreventAutoConnectWithCommandLineArgs=True
 
 [Core.Log]
 LogSpatialOSActorChannel=Log
@@ -47,9 +48,6 @@ LogSpatialOSActorChannel=Log
 [/Script/HardwareTargeting.HardwareTargetingSettings]
 TargetedHardwareClass=Desktop
 DefaultGraphicsPerformance=Maximum
-
-[/Script/SpatialGDK.SpatialGameInstance]
-bPreventAutoConnectWithLocator=False
 
 [/Script/NavigationSystem.NavigationSystemV1]
 bAllowClientSideNavigation=True

--- a/Game/Source/GDKShooter/Private/GameFramework/CrossServerPawn.cpp
+++ b/Game/Source/GDKShooter/Private/GameFramework/CrossServerPawn.cpp
@@ -1,0 +1,15 @@
+ // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "GameFramework/CrossServerPawn.h"
+
+float ACrossServerPawn::TakeDamage(float Damage, const FDamageEvent& DamageEvent, AController* EventInstigator, AActor* DamageCauser)
+{
+	TakeDamageCrossServer(Damage, DamageEvent, nullptr, DamageCauser);
+	return Damage;
+}
+
+void ACrossServerPawn::TakeDamageCrossServer_Implementation(float Damage, const FDamageEvent& DamageEvent, AController* EventInstigator, AActor* DamageCauser)
+{
+	float ActualDamage = Super::TakeDamage(Damage, DamageEvent, EventInstigator, DamageCauser);
+	IncomingDamage.Broadcast(ActualDamage, DamageEvent, EventInstigator, DamageCauser);
+}

--- a/Game/Source/GDKShooter/Public/GameFramework/CrossServerPawn.h
+++ b/Game/Source/GDKShooter/Public/GameFramework/CrossServerPawn.h
@@ -1,0 +1,25 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Pawn.h"
+#include "CrossServerPawn.generated.h"
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_FourParams(FIncomingDamageEvent, float, Damage, const struct FDamageEvent&, DamageEvent, AController*, EventInstigator, AActor*, DamageCauser);
+
+UCLASS()
+class GDKSHOOTER_API ACrossServerPawn : public APawn
+{
+	GENERATED_BODY()
+
+public:
+	UPROPERTY(BlueprintAssignable)
+		FIncomingDamageEvent IncomingDamage;
+
+	float TakeDamage(float Damage, const struct FDamageEvent& DamageEvent, AController* EventInstigator, AActor* DamageCauser) override;
+
+	UFUNCTION(CrossServer, Reliable)
+		void TakeDamageCrossServer(float Damage, const struct FDamageEvent& DamageEvent, AController* EventInstigator, AActor* DamageCauser);
+	
+};


### PR DESCRIPTION
Patching up the effects of removing this class is ugly. The way damage works probably needs a rewrite if we want to do this properly and remove CrossServerPawn. 