### PR TITLE
Symlink the UnrealEngine to a static location

### DIFF
--- a/ci/setup-and-build.ps1
+++ b/ci/setup-and-build.ps1
@@ -5,7 +5,9 @@ param(
   [string] $deployment_launch_configuration = "one_worker_test.json",
   [string] $deployment_snapshot_path = "snapshots/FPS-Start_Small.snapshot",
   [string] $deployment_cluster_region = "eu",
-  [string] $project_name = "unreal_gdk"
+  [string] $project_name = "unreal_gdk",
+  [string] $build_home = (Get-Item "$($PSScriptRoot)").parent.parent.FullName, ## The root of the entire build. Should ultimately resolve to "C:\b\<number>\".
+  [string] $unreal_engine_symlink_dir = "$build_home\UnrealEngine"
 )
 
 . "$PSScriptRoot\common.ps1"
@@ -50,8 +52,7 @@ pushd "$exampleproject_home"
     # Use the cached engine version or set it up if it has not been cached yet.
     Start-Event "set-up-engine" "build-unreal-gdk-example-project-:windows:"
 
-        $engine_directory = "${exampleproject_home}\UnrealEngine"
-        &"$($gdk_home)\ci\get-engine.ps1" -unreal_path "$engine_directory"
+        &"$($gdk_home)\ci\get-engine.ps1" -unreal_path "$unreal_engine_symlink_dir"
 
     Finish-Event "set-up-engine" "build-unreal-gdk-example-project-:windows:"
 

--- a/ci/setup-and-build.ps1
+++ b/ci/setup-and-build.ps1
@@ -57,13 +57,13 @@ pushd "$exampleproject_home"
     Finish-Event "set-up-engine" "build-unreal-gdk-example-project-:windows:"
 
     Start-Event "associate-uproject-with-engine" "build-unreal-gdk-example-project-:windows:"
-        pushd $engine_directory
+        pushd $unreal_engine_symlink_dir
             $unreal_version_selector_path = "Engine\Binaries\Win64\UnrealVersionSelector.exe"
 
             $find_engine_process = Start-Process -Wait -PassThru -NoNewWindow -FilePath $unreal_version_selector_path -ArgumentList @(`
                 "-switchversionsilent", `
                 "${exampleproject_home}\Game\GDKShooter.uproject", `
-                "$engine_directory"
+                "$unreal_engine_symlink_dir"
             )
 
             if ($find_engine_process.ExitCode -ne 0) {

--- a/ci/setup-and-build.ps1
+++ b/ci/setup-and-build.ps1
@@ -98,7 +98,7 @@ pushd "$exampleproject_home"
 
     # Invoke the GDK commandlet to generate schema and snapshot. Note: this needs to be run prior to cooking 
     Start-Event "generate-schema" "build-unreal-gdk-example-project-:windows:"
-        pushd "UnrealEngine/Engine/Binaries/Win64"
+        pushd "${unreal_engine_symlink_dir}/Engine/Binaries/Win64"
             Start-Process -Wait -PassThru -NoNewWindow -FilePath ((Convert-Path .) + "\UE4Editor.exe") -ArgumentList @(`
                 "$($exampleproject_home)/Game/GDKShooter.uproject", `
                 "-run=GenerateSchemaAndSnapshots", `
@@ -139,7 +139,7 @@ pushd "$exampleproject_home"
     Finish-Event "build-linux-worker" "build-unreal-gdk-example-project-:windows:"
 
     Start-Event "build-android-client" "build-unreal-gdk-example-project-:windows:"
-        $unreal_uat_path = "${exampleproject_home}\UnrealEngine\Engine\Build\BatchFiles\RunUAT.bat"
+        $unreal_uat_path = "${unreal_engine_symlink_dir}\Engine\Build\BatchFiles\RunUAT.bat"
         $build_server_proc = Start-Process -PassThru -NoNewWindow -FilePath $unreal_uat_path -ArgumentList @(`
             "-ScriptsForProject=$($exampleproject_home)/Game/GDKShooter.uproject", `
             "BuildCookRun", `
@@ -152,7 +152,7 @@ pushd "$exampleproject_home"
             "-archivedirectory=$($exampleproject_home)/cooked-android", `
             "-package", `
             "-clientconfig=Development", `
-            "-ue4exe=$($exampleproject_home)/UnrealEngine/Engine/Binaries/Win64/UE4Editor-Cmd.exe", `
+            "-ue4exe=$($unreal_engine_symlink_dir)/Engine/Binaries/Win64/UE4Editor-Cmd.exe", `
             "-pak", `
             "-prereqs", `
             "-nodebuginfo", `


### PR DESCRIPTION
Because we were using the project directory to symlink the engine in this script, the location of the fastbuild database was changing for each project that ran a build on a single agent.
Fastbuild databases are not meant to be moved as they are path maps, doing so causes the build to fail.

In the UnrealGDK we symlink the UnrealEngine to a static location that doesn't include the project name, I have replicated this here.

We did not notice this issue before as the various CI pipelines were using different build queues and thus the same agents were not used.

Build: https://buildkite.com/improbable/unrealgdkexampleproject-nightly/builds/876

Equivalent GDK PR: https://github.com/spatialos/UnrealGDK/pull/1962
Equivalent TestGyms PR: https://github.com/improbable/TestGymBuildKite/pull/52