### PR TITLE
make sure all maps get cooked

### DIFF
--- a/Game/Config/DefaultGame.ini
+++ b/Game/Config/DefaultGame.ini
@@ -4,12 +4,22 @@ ProjectName=SpatialOS Unreal GDK Shooter
 CopyrightNotice=Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 bSpatialNetworking=True
 
-[/Script/UnrealEd.ProjectPackagingSettings]
-+DirectoriesToAlwaysCook=(Path="Spatial")
-
 [/Script/Engine.RendererSettings]
 r.LightPropagationVolume = 1
 
 [/Script/Engine.GameSession]
 MaxPlayers=100
 MaxSpectators=100
+
+[/Script/UnrealEd.ProjectPackagingSettings]
++MapsToCook=(FilePath="/Game/Maps/FPS-Start_Tiny")
++MapsToCook=(FilePath="/Game/Maps/FPS-Start_SmallTown")
++MapsToCook=(FilePath="/Game/Maps/FPS-Start_Small")
++MapsToCook=(FilePath="/Game/Maps/FPS-Start_Medium")
++MapsToCook=(FilePath="/Game/Maps/FPS-Start_Large_Limited_Spawns")
++MapsToCook=(FilePath="/Game/Maps/FPS-Start_Large")
++MapsToCook=(FilePath="/Game/Maps/FPS_Test_Gym_01")
++MapsToCook=(FilePath="/Game/Maps/CrashBot_Gym")
++MapsToCook=(FilePath="/Game/Maps/Corridor_Gym")
++MapsToCook=(FilePath="/Game/Maps/Control_Medium")
++DirectoriesToAlwaysCook=(Path="/Game/Spatial")


### PR DESCRIPTION
When packaging a game it only contained the FPS-Start_Medium map. Explicitly listing all maps in the Packaging settings fixes this.