### PR TITLE
Fix APlayerState::PlayerId deprecation warnings

### DIFF
--- a/Game/Source/GDKShooter/Private/Characters/Components/HealthComponent.cpp
+++ b/Game/Source/GDKShooter/Private/Characters/Components/HealthComponent.cpp
@@ -79,7 +79,11 @@ void UHealthComponent::TakeDamage(float Damage, const FDamageEvent& DamageEvent,
 		APlayerState* InstigatorPlayerState = EventInstigator->PlayerState;
 		if (InstigatorPlayerState != nullptr)
 		{
+#if ENGINE_MINOR_VERSION <= 24
 			InstigatorPlayerId = InstigatorPlayerState->PlayerId;
+#else
+			InstigatorPlayerId = InstigatorPlayerState->GetPlayerId();
+#endif
 			if (const UTeamComponent* TeamComponent = InstigatorPlayerState->FindComponentByClass<UTeamComponent>())
 			{
 				InstigatorTeamId = TeamComponent->GetTeam();

--- a/Game/Source/GDKShooter/Private/Characters/Components/HealthComponent.cpp
+++ b/Game/Source/GDKShooter/Private/Characters/Components/HealthComponent.cpp
@@ -1,11 +1,14 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 
 #include "Characters/Components/HealthComponent.h"
+
+#include "GameFramework/Pawn.h"
+#include "Net/UnrealNetwork.h"
+#include "Runtime/Launch/Resources/Version.h"
+
 #include "Controllers/Components/ControllerEventsComponent.h"
 #include "Game/Components/ScorePublisher.h"
-#include "GameFramework/Pawn.h"
 #include "Characters/Components/TeamComponent.h"
-#include "Net/UnrealNetwork.h"
 
 UHealthComponent::UHealthComponent()
 {

--- a/Game/Source/GDKShooter/Private/Controllers/Components/ControllerEventsComponent.cpp
+++ b/Game/Source/GDKShooter/Private/Controllers/Components/ControllerEventsComponent.cpp
@@ -1,9 +1,10 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 
 #include "Controllers/Components/ControllerEventsComponent.h"
+
 #include "GameFramework/Controller.h"
 #include "GameFramework/PlayerState.h"
-
+#include "Runtime/Launch/Resources/Version.h"
 
 UControllerEventsComponent::UControllerEventsComponent()
 {

--- a/Game/Source/GDKShooter/Private/Controllers/Components/ControllerEventsComponent.cpp
+++ b/Game/Source/GDKShooter/Private/Controllers/Components/ControllerEventsComponent.cpp
@@ -19,7 +19,11 @@ void UControllerEventsComponent::Death_Implementation(const AController* Killer)
 		APlayerState* KillerPlayerState = Killer->PlayerState;
 		if (KillerPlayerState != nullptr)
 		{
+#if ENGINE_MINOR_VERSION <= 24
 			ClientInformOfDeath(KillerPlayerState->GetPlayerName(), KillerPlayerState->PlayerId);
+#else
+			ClientInformOfDeath(KillerPlayerState->GetPlayerName(), KillerPlayerState->GetPlayerId());
+#endif
 		}
 		else
 		{
@@ -37,7 +41,11 @@ void UControllerEventsComponent::Kill_Implementation(const AController* Victim)
 		APlayerState* VictimPlayerState = Victim->PlayerState;
 		if (VictimPlayerState != nullptr)
 		{
+#if ENGINE_MINOR_VERSION <= 24
 			ClientInformOfKill(VictimPlayerState->GetPlayerName(), VictimPlayerState->PlayerId);
+#else
+			ClientInformOfKill(VictimPlayerState->GetPlayerName(), VictimPlayerState->GetPlayerId());
+#endif
 		}
 	}
 }

--- a/Game/Source/GDKShooter/Private/Game/Components/DeathmatchScoreComponent.cpp
+++ b/Game/Source/GDKShooter/Private/Game/Components/DeathmatchScoreComponent.cpp
@@ -18,10 +18,16 @@ void UDeathmatchScoreComponent::GetLifetimeReplicatedProps(TArray<FLifetimePrope
 
 void UDeathmatchScoreComponent::RecordNewPlayer(APlayerState* PlayerState)
 {
-	if (!PlayerScoreMap.Contains(PlayerState->PlayerId))
+#if ENGINE_MINOR_VERSION <= 24
+	const int32 NewPlayerId = PlayerState->PlayerId;
+#else
+	const int32 NewPlayerId = PlayerState->GetPlayerId();
+#endif
+
+	if (!PlayerScoreMap.Contains(NewPlayerId))
 	{
 		FPlayerScore NewPlayerScore;
-		NewPlayerScore.PlayerId = PlayerState->PlayerId;
+		NewPlayerScore.PlayerId = NewPlayerId;
 		NewPlayerScore.PlayerName = PlayerState->GetPlayerName();
 		NewPlayerScore.Kills = 0;
 		NewPlayerScore.Deaths = 0;

--- a/Game/Source/GDKShooter/Private/Game/Components/DeathmatchScoreComponent.cpp
+++ b/Game/Source/GDKShooter/Private/Game/Components/DeathmatchScoreComponent.cpp
@@ -1,7 +1,9 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 
 #include "Game/Components/DeathmatchScoreComponent.h"
+
 #include "Net/UnrealNetwork.h"
+#include "Runtime/Launch/Resources/Version.h"
 
 UDeathmatchScoreComponent::UDeathmatchScoreComponent()
 {

--- a/Game/Source/GDKShooter/Private/Game/Components/TeamDeathmatchScoreComponent.cpp
+++ b/Game/Source/GDKShooter/Private/Game/Components/TeamDeathmatchScoreComponent.cpp
@@ -1,8 +1,10 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 
-
 #include "Game/Components/TeamDeathmatchScoreComponent.h"
+
 #include "Net/UnrealNetwork.h"
+#include "Runtime/Launch/Resources/Version.h"
+
 #include "Characters/Components/TeamComponent.h"
 
 UTeamDeathmatchScoreComponent::UTeamDeathmatchScoreComponent()

--- a/Game/Source/GDKShooter/Private/Game/Components/TeamDeathmatchScoreComponent.cpp
+++ b/Game/Source/GDKShooter/Private/Game/Components/TeamDeathmatchScoreComponent.cpp
@@ -29,12 +29,18 @@ void UTeamDeathmatchScoreComponent::SetTeamScores(TArray<FTeamScore> InitialTeam
 
 void UTeamDeathmatchScoreComponent::RecordNewPlayer(APlayerState* PlayerState)
 {
-	if (!PlayerScoreMap.Contains(PlayerState->PlayerId))
+#if ENGINE_MINOR_VERSION <= 24
+	const int32 NewPlayerId = PlayerState->PlayerId;
+#else
+	const int32 NewPlayerId = PlayerState->GetPlayerId();
+#endif
+
+	if (!PlayerScoreMap.Contains(NewPlayerId))
 	{
 		if (const UTeamComponent* TeamComponent = PlayerState->FindComponentByClass<UTeamComponent>())
 		{
 			FPlayerScore NewPlayerScore;
-			NewPlayerScore.PlayerId = PlayerState->PlayerId;
+			NewPlayerScore.PlayerId = NewPlayerId;
 			NewPlayerScore.PlayerName = PlayerState->GetPlayerName();
 			NewPlayerScore.Kills = 0;
 			NewPlayerScore.Deaths = 0;
@@ -70,7 +76,13 @@ void UTeamDeathmatchScoreComponent::RecordNewPlayer(APlayerState* PlayerState)
 
 void UTeamDeathmatchScoreComponent::RemovePlayer(APlayerState* PlayerState)
 {
-	if (PlayerScoreMap.Contains(PlayerState->PlayerId))
+#if ENGINE_MINOR_VERSION <= 24
+	const int32 RemovedPlayerId = PlayerState->PlayerId;
+#else
+	const int32 RemovedPlayerId = PlayerState->GetPlayerId();
+#endif
+
+	if (PlayerScoreMap.Contains(RemovedPlayerId))
 	{
 		if (const UTeamComponent* TeamComponent = PlayerState->FindComponentByClass<UTeamComponent>())
 		{
@@ -78,7 +90,7 @@ void UTeamDeathmatchScoreComponent::RemovePlayer(APlayerState* PlayerState)
 			if (TeamScoreMap.Contains(TeamId))
 			{
 				TArray<FPlayerScore>* PlayerScores = &TeamScoreArray[TeamScoreMap[TeamId]].PlayerScores;
-				PlayerScores->RemoveAt(PlayerScoreMap[PlayerState->PlayerId]);
+				PlayerScores->RemoveAt(PlayerScoreMap[RemovedPlayerId]);
 				for (int i = 0; i < PlayerScores->Num(); i++)
 				{
 					int32 PlayerId = (*PlayerScores)[i].PlayerId;
@@ -87,23 +99,29 @@ void UTeamDeathmatchScoreComponent::RemovePlayer(APlayerState* PlayerState)
 			}
 		}
 
-		PlayerScoreMap.Remove(PlayerState->PlayerId);
+		PlayerScoreMap.Remove(RemovedPlayerId);
 	}
 }
 
 void UTeamDeathmatchScoreComponent::RecordKill(APlayerState* KillerState, APlayerState* VictimState)
 {
-	if (PlayerScoreMap.Contains(KillerState->PlayerId))
+#if ENGINE_MINOR_VERSION <= 24
+	const int32 KillerId = KillerState->PlayerId;
+	const int32 VictimId = VictimState->PlayerId;
+#else
+	const int32 KillerId = KillerState->GetPlayerId();
+	const int32 VictimId = VictimState->GetPlayerId();
+#endif
+
+	if (PlayerScoreMap.Contains(KillerId))
 	{
-		const int32 KillerId = KillerState->PlayerId;
 		const uint8 KillerTeamId = KillerState->FindComponentByClass<UTeamComponent>()->GetTeam().GetId();
 
 		++TeamScoreArray[TeamScoreMap[KillerTeamId]].PlayerScores[PlayerScoreMap[KillerId]].Kills;
 	}
 
-	if (PlayerScoreMap.Contains(VictimState->PlayerId))
+	if (PlayerScoreMap.Contains(VictimId))
 	{
-		const int32 VictimId = VictimState->PlayerId;
 		const uint8 VictimTeamId = VictimState->FindComponentByClass<UTeamComponent>()->GetTeam().GetId();
 
 		++TeamScoreArray[TeamScoreMap[VictimTeamId]].PlayerScores[PlayerScoreMap[VictimId]].Deaths;


### PR DESCRIPTION
Using `APlayerState::PlayerId` directly is deprecated in 4.25.