### PR TITLE
UE 4.25 for example project

### DIFF
--- a/ci/nightly.template.steps.yaml
+++ b/ci/nightly.template.steps.yaml
@@ -22,7 +22,7 @@ windows: &windows
     - "permission_set=builder"
     - "platform=windows"
     - "scaler_version=2"
-    - "queue=${CI_WINDOWS_BUILDER_QUEUE:-v4-20-03-26-102432-bk9951-8afe0ffb}"
+    - "queue=${CI_WINDOWS_BUILDER_QUEUE:-v4-20-07-20-102655-bk13456-70b30abf-d}"
     - "boot_disk_size_gb=500"
   timeout_in_minutes: 60 # TODO(ENG-548): reduce timeout once agent-cold-start is optimised.
   retry:
@@ -63,3 +63,4 @@ steps:
       STEP_NUMBER: "${STEP_NUMBER}"
       GDK_BRANCH: "${GDK_BRANCH}"
       UE-SharedDataCachePath: "\\\\gdk-for-unreal-cache.${CI_ENVIRONMENT}-intinf-eu1.i8e.io\\samba\\ddc"
+      NDKROOT: "c:/Android/android-ndk-r21d"


### PR DESCRIPTION
With UE 4.25 we need to use NDK 21 for Android builds. This will update the example project to use NDK 21 during CI.