### PR TITLE
UNR-3998 Fix 4.25 Android file name error and modify some comments

### DIFF
--- a/.buildkite/nightly.steps.yaml
+++ b/.buildkite/nightly.steps.yaml
@@ -30,6 +30,7 @@ script_runner: &script_runner
       - <<: *bk_system_error
       - <<: *bk_interrupted_by_signal
 
+# TODO: UNR-3894 Replace the windows agent with a linux agent
 windows: &windows
   agents:
     - "agent_count=1"

--- a/ci/change-runtime-settings.py
+++ b/ci/change-runtime-settings.py
@@ -33,7 +33,7 @@ class CustomWriter:
         self.output_file.write(what.replace('\n\t','\n'))
         
 
-# modify runtime settings before cook
+# Modify runtime settings before cook
 def change_runtime_settings(project_home):
     default_engine_ini = os.path.join(project_home, 'Game', 'Config', 'DefaultEngine.ini')
     config = configparser.ConfigParser(strict=False, dict_type=MultiOrderedDict, interpolation=CustomInterpolation())
@@ -44,7 +44,7 @@ def change_runtime_settings(project_home):
     if not config.has_section(IOSRuntimeSettings):
         config.add_section(IOSRuntimeSettings)
     
-    # for ios runtime settings
+    # Modify iOS runtime settings
     AdditionalPlistData = '<key>CFBundleURLTypes</key><array><dict><key>CFBundleURLName</key><string></string><key>CFBundleTypeRole</key><string>Editor</string><key>CFBundleURLSchemes</key><array><string>firebase-game-loop</string></array></dict></array>'
     config[IOSRuntimeSettings]['AdditionalPlistData'] = AdditionalPlistData
     config[IOSRuntimeSettings]['BundleIdentifier'] = 'io.improbable.unrealgdkdemo'
@@ -59,7 +59,7 @@ def change_runtime_settings(project_home):
     config[IOSRuntimeSettings]['bEnableAdvertisingIdentifier'] = 'False'
     config[IOSRuntimeSettings]['bEnableCloudKitSupport'] = 'False'
     
-    # for Android extra activity settings
+    # Modify Android extra activity settings
     AndroidRuntimeSettings = '/Script/AndroidRuntimeSettings.AndroidRuntimeSettings'
     if not config.has_section(AndroidRuntimeSettings):
         config.add_section(AndroidRuntimeSettings)

--- a/ci/deploy.ps1
+++ b/ci/deploy.ps1
@@ -6,7 +6,7 @@ param(
 . "$PSScriptRoot\common.ps1"
 
 Start-Event "deploy-game" "build-unreal-gdk-example-project-:windows:"
-    # deployment_name is created during the  generate-auth_token-and-deployment-name step
+    # deployment_name is created during the generate-auth_token-and-deployment-name step
     $deployment_name = buildkite-agent meta-data get "deployment-name-$($env:STEP_NUMBER)"    
     $assembly_name = "$($deployment_name)_asm"
     $runtime_version = Get-Env-Variable-Value-Or-Default -environment_variable_name "SPATIAL_RUNTIME_VERSION" -default_value ""

--- a/ci/generate-auth-token.ps1
+++ b/ci/generate-auth-token.ps1
@@ -27,7 +27,7 @@ Finish-Event "generate-project-name" "generate-auth-token-and-deployment-:window
 pushd "$exampleproject_home" 
     pushd "spatial"
         Start-Event "generate-auth-token" "generate-auth-token-and-deployment-:windows:"
-            $dev_auth_token_result = spatial project auth dev-auth-token create --description="Token generated for Example Project CI" --project_name=$project_name | Out-String
+            $dev_auth_token_result = spatial project auth dev-auth-token create --description="Token generated for Example Project CI" --lifetime=24h --project_name=$project_name | Out-String
             $found_dev_token = $dev_auth_token_result -match 'token_secret:\\"(.+)\\"'
             if ($found_dev_token -eq 0) {
                 Write-Log "Failed to find dev auth token"

--- a/ci/generate-pipeline-steps.sh
+++ b/ci/generate-pipeline-steps.sh
@@ -43,10 +43,9 @@ insert_setup_build_step(){
     AGENT="${2}"
     COMMAND="${3}"
     FILENAME="ci/nightly.template.steps.yaml"
-    # ENGINE_COMMIT_FORMATTED_HASH means it from ENGINE_COMMIT_HASH but only change ' ','.','-' as '_'
+    # ENGINE_COMMIT_FORMATTED_HASH is the same as ENGINE_COMMIT_HASH, but replace ' ','.','-' with '_' to use it as a buildkite key.
     # So as to make the steps indentify for different engine_version
-    # We use ENGINE_COMMIT_FORMATTED_HASH for buildkite key and depends_on can not have spaces
-    # For more information:https://buildkite.com/docs/pipelines/block-step#text-input-attributes
+    # For more information: https://buildkite.com/docs/pipelines/block-step#text-input-attributes
     ENGINE_COMMIT_FORMATTED_HASH=$(sed "s/ /_/g" <<< ${VERSION} | sed "s/-/_/g" | sed "s/\./_/g")
     REPLACE_ENGINE_COMMIT_HASH="s|ENGINE_COMMIT_HASH_PLACEHOLDER|${VERSION}|g"
     REPLACE_ENGINE_COMMIT_FORMATTED_HASH="s|ENGINE_COMMIT_FORMATTED_HASH_PLACEHOLDER|${ENGINE_COMMIT_FORMATTED_HASH}|g"

--- a/ci/nightly.android.firebase.test.yaml
+++ b/ci/nightly.android.firebase.test.yaml
@@ -13,6 +13,7 @@ bk_interrupted_by_signal: &bk_interrupted_by_signal
   exit_status: 15
   limit: 3
 
+# TODO: UNR-3893 Replace the windows agent with a linux agent
 windows: &windows
   agents:
     - "agent_count=1"

--- a/ci/nightly.gen.auth.token.yaml
+++ b/ci/nightly.gen.auth.token.yaml
@@ -12,7 +12,8 @@ bk_system_error: &bk_system_error
 bk_interrupted_by_signal: &bk_interrupted_by_signal
   exit_status: 15
   limit: 3
-
+  
+# TODO: UNR-3985 Replace the windows agent with a linux agent
 windows: &windows
   agents:
     - "agent_count=1"

--- a/ci/nightly.ios.firebase.test.yaml
+++ b/ci/nightly.ios.firebase.test.yaml
@@ -13,6 +13,7 @@ bk_interrupted_by_signal: &bk_interrupted_by_signal
   exit_status: 15
   limit: 3
 
+# TODO: UNR-3893 Replace the windows agent with a linux agent
 windows: &windows
   agents:
     - "agent_count=1"

--- a/ci/nightly.template.steps.yaml
+++ b/ci/nightly.template.steps.yaml
@@ -65,7 +65,7 @@ steps:
     env:
       ENGINE_COMMIT_HASH: "ENGINE_COMMIT_HASH_PLACEHOLDER"
       # ENGINE_COMMIT_FORMATTED_HASH is a enviroment variable for subsequent steps
-      # It's very similar to ENGINE_COMMIT_HASH, but replace ' ','.','-' as '_' to distinguish engine_version of UnrealEngine.
+      # It's very similar to ENGINE_COMMIT_HASH, but it replace ' ','.','-' with '_' to be able to use it as a buildkite key to distinguish between engine versions.
       # For more information: https://buildkite.com/docs/pipelines/block-step#text-input-attributes
       ENGINE_COMMIT_FORMATTED_HASH: "ENGINE_COMMIT_FORMATTED_HASH_PLACEHOLDER"
       STEP_NUMBER: "${STEP_NUMBER}"

--- a/ci/nightly.template.steps.yaml
+++ b/ci/nightly.template.steps.yaml
@@ -65,7 +65,7 @@ steps:
     env:
       ENGINE_COMMIT_HASH: "ENGINE_COMMIT_HASH_PLACEHOLDER"
       # ENGINE_COMMIT_FORMATTED_HASH is a enviroment variable for subsequent steps
-      # It's very similar to ENGINE_COMMIT_HASH, but it replace ' ','.','-' with '_' to be able to use it as a buildkite key to distinguish between engine versions.
+      # It's very similar to ENGINE_COMMIT_HASH, but it replaces ' ','.','-' with '_' to be able to use it as a buildkite key to distinguish between engine versions.
       # For more information: https://buildkite.com/docs/pipelines/block-step#text-input-attributes
       ENGINE_COMMIT_FORMATTED_HASH: "ENGINE_COMMIT_FORMATTED_HASH_PLACEHOLDER"
       STEP_NUMBER: "${STEP_NUMBER}"

--- a/ci/run-firebase-test.py
+++ b/ci/run-firebase-test.py
@@ -88,7 +88,7 @@ def get_gcs_and_local_path(app_platform, engine_commit_formatted_hash):
     localfilename = ''
     path = 'cooked-%s' % app_platform
     if app_platform == 'android':
-        # UnrealEngine for 4.24-SpatialOSUnrealGDK have different android file name
+        # UnrealEngine 4.24 and 4.25 create different android file names
         if '4_24' in engine_commit_formatted_hash:
             localfilename = 'GDKShooter-armv7-es2.apk'
         else:

--- a/ci/run-firebase-test.py
+++ b/ci/run-firebase-test.py
@@ -17,7 +17,7 @@ import sys
 import common
 import platform
 
-# Base on artifact_paths of nightly.android.firebase.test.yaml and nightly.ios.firebase.test.yaml
+# Based on artifact_paths in nightly.android.firebase.test.yaml and nightly.ios.firebase.test.yaml
 FIREBASE_LOG_DIR="firebase_log"
 
 def switch_gcloud_project(project_id):
@@ -88,8 +88,12 @@ def get_gcs_and_local_path(app_platform, engine_commit_formatted_hash):
     localfilename = ''
     path = 'cooked-%s' % app_platform
     if app_platform == 'android':
-        localfilename = 'GDKShooter-armv7-es2.apk'
-        filename = '%s/Android_ASTC/%s' % (path, localfilename)
+        # UnrealEngine for 4.24-SpatialOSUnrealGDK have different android file name
+        if '4_24' in engine_commit_formatted_hash:
+            localfilename = 'GDKShooter-armv7-es2.apk'
+        else:
+            localfilename = 'GDKShooter-armv7.apk'
+        filename = '%s/Android_ETC2/%s' % (path, localfilename)
         agentplatform = 'windows'
     else:
         localfilename = 'GDKShooter.ipa'

--- a/ci/setup-and-build.ps1
+++ b/ci/setup-and-build.ps1
@@ -127,7 +127,7 @@ pushd "$exampleproject_home"
             "Development", `
             "GDKShooter.uproject", `
             "-nocompile"
-        )       
+        )
         $build_client_handle = $build_client_proc.Handle
         Wait-Process -InputObject $build_client_proc
         if ($build_client_proc.ExitCode -ne 0) {
@@ -143,7 +143,7 @@ pushd "$exampleproject_home"
             "Development", `
             "GDKShooter.uproject", `
             "-nocompile"
-        )       
+        )
         $build_server_handle = $build_server_proc.Handle
         Wait-Process -InputObject $build_server_proc
 
@@ -188,7 +188,7 @@ pushd "$exampleproject_home"
             "-prereqs", `
             "-nodebuginfo", `
             "-targetplatform=Android", `
-            "-cookflavor=ASTC", `
+            "-cookflavor=ETC2", `
             "-build", `
             "-utf8output", `
             "-cmdline=`"${cmdline}`""

--- a/ci/setup-and-build.ps1
+++ b/ci/setup-and-build.ps1
@@ -171,7 +171,7 @@ pushd "$exampleproject_home"
         Write-Host "Cloud deployment to connect to: $deployment_name"
         $cmdline="127.0.0.1 -workerType UnrealClient -devauthToken $auth_token -deployment $deployment_name -linkProtocol Tcp"
 
-        $argumentlist = [System.Collections.ArrayList]@(`
+        $argumentlist = @(`
             "-ScriptsForProject=$game_project", `
             "BuildCookRun", `
             "-nocompileeditor", `


### PR DESCRIPTION
the file name of Android build with UnrealEngine 4.25-SpatialOSUnrealGDK(GDKShooter-armv7.ap) is different from 4.24-SpatialOSUnrealGDK(GDKShooter-armv7-es2.apk)
change something as comments from old PR
(https://github.com/spatialos/UnrealGDKExampleProject/pull/195)
--------------------
Jira Tickets:
https://improbableio.atlassian.net/browse/UNR-3998

Successful default build:
https://buildkite.com/improbable/unrealgdkexampleproject-nightly/builds/2732

successful completely build:
MAC_BUILD=true
FIREBASE_TEST=true
ENGINE_VERSION="HEAD 4.25-SpatialOSUnrealGDK"
https://buildkite.com/improbable/unrealgdkexampleproject-nightly/builds/2733