### PR TITLE
Fix iOS Firebase tests

### DIFF
--- a/ci/deploy.ps1
+++ b/ci/deploy.ps1
@@ -6,14 +6,16 @@ param(
 . "$PSScriptRoot\common.ps1"
 
 # Grab Artifacts
-Start-Event "fetch-artifacts" "Upload Assembly"
-  New-Item -ItemType directory -Path staging | Out-Null
-  if (-Not (Test-Path Game/Content/Spatial)) {New-Item -ItemType directory -Path Stavka\Game\Content\Spatial}
-  buildkite-agent artifact download "*Schema.zip" staging
-  7z x staging/artifacts/Schema.zip -aoa -ospatial
-  buildkite-agent artifact download "*Snapshots.zip" staging
-  7z x staging/artifacts/Snapshots.zip -aoa -ospatial
-Finish-Event "fetch-artifacts" "Upload Assembly"
+Start-Event "fetch-artifacts" "build-unreal-gdk-example-project-:windows:"
+    New-Item -ItemType directory -Path staging | Out-Null
+    if (-Not (Test-Path Game/Content/Spatial)) {
+        New-Item -ItemType directory -Path Game\Content\Spatial
+    }
+    buildkite-agent artifact download "*Schema.zip" staging
+    7z x staging/artifacts/Schema.zip -aoa -ospatial
+    buildkite-agent artifact download "*Snapshots.zip" staging
+    7z x staging/artifacts/Snapshots.zip -aoa -ospatial
+Finish-Event "fetch-artifacts" "build-unreal-gdk-example-project-:windows:"
 
 Start-Event "deploy-game" "build-unreal-gdk-example-project-:windows:"
     # deployment_name is created during the generate-auth_token-and-deployment-name step

--- a/ci/deploy.ps1
+++ b/ci/deploy.ps1
@@ -5,16 +5,18 @@ param(
 
 . "$PSScriptRoot\common.ps1"
 
+
 # Grab Artifacts
 Start-Event "fetch-artifacts" "build-unreal-gdk-example-project-:windows:"
+    $schema_path = "Game\Content\Spatial"
     New-Item -ItemType directory -Path staging | Out-Null
-    if (-Not (Test-Path Game/Content/Spatial)) {
-        New-Item -ItemType directory -Path Game\Content\Spatial
+    if (-Not (Test-Path $schema_path)) {
+        New-Item -ItemType directory -Path $schema_path
     }
     buildkite-agent artifact download "*Schema.zip" staging
-    7z x staging/artifacts/Schema.zip -aoa -ospatial
+    7z x staging\artifacts\Schema.zip -aoa -ospatial
     buildkite-agent artifact download "*Snapshots.zip" staging
-    7z x staging/artifacts/Snapshots.zip -aoa -ospatial
+    7z x staging\artifacts\Snapshots.zip -aoa -ospatial
 Finish-Event "fetch-artifacts" "build-unreal-gdk-example-project-:windows:"
 
 Start-Event "deploy-game" "build-unreal-gdk-example-project-:windows:"

--- a/ci/deploy.ps1
+++ b/ci/deploy.ps1
@@ -5,7 +5,6 @@ param(
 
 . "$PSScriptRoot\common.ps1"
 
-
 # Grab Artifacts
 Start-Event "fetch-artifacts" "build-unreal-gdk-example-project-:windows:"
     $schema_path = "Game\Content\Spatial"

--- a/ci/deploy.ps1
+++ b/ci/deploy.ps1
@@ -5,6 +5,16 @@ param(
 
 . "$PSScriptRoot\common.ps1"
 
+# Grab Artifacts
+Start-Event "fetch-artifacts" "Upload Assembly"
+  New-Item -ItemType directory -Path staging | Out-Null
+  if (-Not (Test-Path Game/Content/Spatial)) {New-Item -ItemType directory -Path Stavka\Game\Content\Spatial}
+  buildkite-agent artifact download "*Schema.zip" staging
+  7z x staging/artifacts/Schema.zip -aoa -ospatial
+  buildkite-agent artifact download "*Snapshots.zip" staging
+  7z x staging/artifacts/Snapshots.zip -aoa -ospatial
+Finish-Event "fetch-artifacts" "Upload Assembly"
+
 Start-Event "deploy-game" "build-unreal-gdk-example-project-:windows:"
     # deployment_name is created during the generate-auth_token-and-deployment-name step
     $deployment_name = buildkite-agent meta-data get "deployment-name-$($env:STEP_NUMBER)"    

--- a/ci/nightly.android.firebase.test.yaml
+++ b/ci/nightly.android.firebase.test.yaml
@@ -25,6 +25,7 @@ windows: &windows
     - "scaler_version=2"
     - "queue=${CI_WINDOWS_BUILDER_QUEUE:-v4-20-08-03-061331-bk13849-b66f334e-d}"
     - "boot_disk_size_gb=500"
+    - "experiment_normalised_upload_paths=true"
   timeout_in_minutes: 60
   retry:
     automatic:

--- a/ci/nightly.gen.auth.token.yaml
+++ b/ci/nightly.gen.auth.token.yaml
@@ -19,12 +19,13 @@ windows: &windows
     - "agent_count=1"
     - "capable_of_building=gdk-for-unreal"
     - "environment=production"
-    - "machine_type=quarter"
+    - "machine_type=quad"
     - "permission_set=builder"
     - "platform=windows"
     - "scaler_version=2"
     - "queue=${CI_WINDOWS_BUILDER_QUEUE:-v4-20-08-03-061331-bk13849-b66f334e-d}"
     - "boot_disk_size_gb=500"
+    - "experiment_normalised_upload_paths=true"
   timeout_in_minutes: 60
   retry:
     automatic:
@@ -35,7 +36,16 @@ windows: &windows
     - ca-johnson/taskkill#v4.1: ~
 
 steps:
-  - label: "generate-auth_token-and-deployment-name"
+  - label: "generate-auth-token-and-deployment-name"
     command: "powershell -NoProfile -NonInteractive -InputFormat Text -Command ./ci/generate-auth-token.ps1"
     <<: *windows 
     key: "generate-auth_token"
+
+  - label: "prepare-editor"
+    command: "powershell -NoProfile -NonInteractive -InputFormat Text -Command ./ci/prep-editor.ps1"
+    <<: *windows 
+    key: "prepare-editor"
+    artifact_paths:
+      - "Game/Content/Spatial/SchemaDatabase.uasset"
+      - "artifacts/Schema.zip"
+      - "artifacts/Snapshots.zip"

--- a/ci/nightly.ios.firebase.test.yaml
+++ b/ci/nightly.ios.firebase.test.yaml
@@ -25,6 +25,7 @@ windows: &windows
     - "scaler_version=2"
     - "queue=${CI_WINDOWS_BUILDER_QUEUE:-v4-20-08-03-061331-bk13849-b66f334e-d}"
     - "boot_disk_size_gb=500"
+    - "experiment_normalised_upload_paths=true"
   timeout_in_minutes: 60
   retry:
     automatic:

--- a/ci/nightly.prepare-editor.steps.yaml
+++ b/ci/nightly.prepare-editor.steps.yaml
@@ -1,0 +1,1 @@
+nightly.prepare-editor.steps.yaml

--- a/ci/nightly.prepare-editor.steps.yaml
+++ b/ci/nightly.prepare-editor.steps.yaml
@@ -1,1 +1,0 @@
-nightly.prepare-editor.steps.yaml

--- a/ci/nightly.template.steps.yaml
+++ b/ci/nightly.template.steps.yaml
@@ -57,10 +57,11 @@ steps:
     key: "setup-and-build-AGENT_PLACEHOLDER-ENGINE_COMMIT_FORMATTED_HASH_PLACEHOLDER"
     depends_on:
       - "generate-auth_token"
+      - "prepare-editor"
     artifact_paths:
       - "UnrealEngine/Engine/Programs/AutomationTool/Saved/Logs/*"
       - "cooked-android/**/*"
-      - "cooked-mac/**/*"
+      - "cooked-mac.zip"
       - "cooked-ios/**/*"
     env:
       ENGINE_COMMIT_HASH: "ENGINE_COMMIT_HASH_PLACEHOLDER"

--- a/ci/prep-editor.ps1
+++ b/ci/prep-editor.ps1
@@ -1,0 +1,145 @@
+param(
+  [string] $exampleproject_home = (get-item "$($PSScriptRoot)").parent.FullName, ## The root of the repo
+  [string] $build_home = (Get-Item "$($PSScriptRoot)").parent.parent.FullName, ## The root of the entire build. Should ultimately resolve to "C:\b\<number>\".
+  [string] $unreal_engine_symlink_dir = "$build_home\UnrealEngine"
+)
+
+. "$PSScriptRoot\common.ps1"
+
+# When a build is launched custom environment variables can be specified.
+# Parse them here to use the set value or the default.
+$gdk_repo = Get-Env-Variable-Value-Or-Default -environment_variable_name "GDK_REPOSITORY" -default_value ""
+$gdk_branch_name = Get-Env-Variable-Value-Or-Default -environment_variable_name "GDK_BRANCH" -default_value "master"
+$engine_commit_formatted_hash = Get-Env-Variable-Value-Or-Default -environment_variable_name "ENGINE_COMMIT_FORMATTED_HASH" -default_value "0"
+$main_map_name = Get-Env-Variable-Value-Or-Default -environment_variable_name "MAIN_MAP_NAME" -default_value "Control_Small"
+$run_firebase_test = Get-Env-Variable-Value-Or-Default -environment_variable_name "FIREBASE_TEST" -default_value "false"
+
+$gdk_home = "$exampleproject_home\Game\Plugins\UnrealGDK"
+$game_project = "$exampleproject_home/Game/GDKShooter.uproject"
+
+pushd "$exampleproject_home"
+    Start-Event "clone-gdk-plugin" "prep-editor"
+        pushd "Game"
+            New-Item -Name "Plugins" -ItemType Directory -Force
+            pushd "Plugins"
+                Start-Process -Wait -PassThru -NoNewWindow -FilePath "git" -ArgumentList @(`
+                    "clone", `
+                    "$gdk_repo", `
+                    "--depth 1", `
+                    "-b $gdk_branch_name"
+                )
+            popd
+        popd
+    Finish-Event "clone-gdk-plugin" "prep-editor"
+
+    Start-Event "set-up-gdk-plugin" "prep-editor"
+        pushd $gdk_home
+            # Invoke the GDK's setup script
+            &"$($gdk_home)\ci\setup-gdk.ps1"
+        popd
+    Finish-Event "set-up-gdk-plugin" "prep-editor"
+
+    # Use the cached engine version or set it up if it has not been cached yet.
+    Start-Event "set-up-engine" "prep-editor"
+        &"$($gdk_home)\ci\get-engine.ps1" -unreal_path "$unreal_engine_symlink_dir"
+    Finish-Event "set-up-engine" "prep-editor"
+
+    Start-Event "associate-uproject-with-engine" "prep-editor"
+        pushd $unreal_engine_symlink_dir
+            $unreal_version_selector_path = "Engine\Binaries\Win64\UnrealVersionSelector.exe"
+
+            $find_engine_process = Start-Process -Wait -PassThru -NoNewWindow -FilePath $unreal_version_selector_path -ArgumentList @(`
+                "-switchversionsilent", `
+                "$game_project", `
+                "$unreal_engine_symlink_dir"
+            )
+
+            if ($find_engine_process.ExitCode -ne 0) {
+                Write-Log "Failed to set Unreal Engine association for the project. Error: $($find_engine_process.ExitCode)"
+                Throw "Failed to set Engine association"
+            }
+        popd
+    Finish-Event "associate-uproject-with-engine" "prep-editor"
+
+    $build_script_path = "$($gdk_home)\SpatialGDK\Build\Scripts\BuildWorker.bat"
+
+    Start-Event "build-editor" "prep-editor"
+        # Build the project editor to allow the snapshot and schema commandlet to run
+        $build_editor_proc = Start-Process -PassThru -NoNewWindow -FilePath $build_script_path -ArgumentList @(`
+            "GDKShooterEditor", `
+            "Win64", `
+            "Development", `
+            "GDKShooter.uproject"
+        )
+
+        # Explicitly hold on to the process handle. 
+        # This works around an issue whereby Wait-Process would fail to find build_editor_proc 
+        $build_editor_handle = $build_editor_proc.Handle
+
+        Wait-Process -InputObject $build_editor_proc
+        if ($build_editor_proc.ExitCode -ne 0) {
+            Write-Log "Failed to build Win64 Development Editor. Error: $($build_editor_proc.ExitCode)"
+            Throw "Failed to build Win64 Development Editor"
+        }
+    Finish-Event "build-editor" "prep-editor"
+
+    # Invoke the GDK commandlet to generate schema and snapshot. Note: this needs to be run prior to cooking 
+    Start-Event "generate-schema" "prep-editor"
+        pushd "${unreal_engine_symlink_dir}/Engine/Binaries/Win64"
+            $UE4Editor=((Convert-Path .) + "\UE4Editor-Cmd.exe")
+            $schema_gen_proc = Start-Process -PassThru -NoNewWindow -FilePath $UE4Editor -ArgumentList @(`
+                "$game_project", `
+                "-run=CookAndGenerateSchema", `
+                "-targetplatform=LinuxServer", `
+                "-SkipShaderCompile", `
+                "-map=`"/Maps/$main_map_name`""
+            )
+            $schema_gen_handle = $schema_gen_proc.Handle
+            Wait-Process -InputObject $schema_gen_proc
+            if ($schema_gen_proc.ExitCode -ne 0) {
+                Write-Log "Failed to generate schema. Error: $($schema_gen_proc.ExitCode)"
+                Throw "Failed to generate schema"
+            }
+            
+            $snapshot_gen_proc = Start-Process -PassThru -NoNewWindow -FilePath $UE4Editor -ArgumentList @(`
+                "$game_project", `
+                "-run=GenerateSnapshot", `
+                "-MapPaths=`"/Maps/$main_map_name`""
+            )
+            $snapshot_gen_handle = $snapshot_gen_proc.Handle
+            Wait-Process -InputObject $snapshot_gen_proc
+            if ($snapshot_gen_proc.ExitCode -ne 0) {
+                Write-Log "Failed to generate snapshot. Error: $($snapshot_gen_proc.ExitCode)"
+                Throw "Failed to generate snapshot"
+            }
+        popd
+    Finish-Event "generate-schema" "prep-editor"
+
+    # Zip the artifacts
+    Start-Event "zip-artifacts" "prep-editor"
+        Write-Log "Zipping Schema..."
+        $zip_proc = Start-Process -Wait -PassThru -NoNewWindow "7z" -ArgumentList @(`
+            "a", `
+            "-mx3", `
+            "artifacts/Schema.zip", `
+            "$PSScriptRoot/../spatial/schema" `
+        )
+        if ($zip_proc.ExitCode -ne 0) {
+            Write-Log "Failed to zip schema. Error: $($zip_proc.ExitCode)"
+            Throw "Schema Zip Failed"
+        }
+
+        Write-Log "Zipping Snapshots..."
+        $zip_proc = Start-Process -Wait -PassThru -NoNewWindow "7z" -ArgumentList @(`
+            "a", `
+            "-mx3", `
+            "artifacts/Snapshots.zip", `
+            "$PSScriptRoot/../spatial/snapshots" `
+        )
+
+        if ($zip_proc.ExitCode -ne 0) {
+            Write-Log "Failed to zip snapshots. Error: $($zip_proc.ExitCode)"
+            Throw "Snapshot Zip Failed"
+        }
+    Finish-Event "zip-artifacts" "prep-editor"
+popd

--- a/ci/prep-editor.ps1
+++ b/ci/prep-editor.ps1
@@ -15,7 +15,7 @@ $main_map_name = Get-Env-Variable-Value-Or-Default -environment_variable_name "M
 $run_firebase_test = Get-Env-Variable-Value-Or-Default -environment_variable_name "FIREBASE_TEST" -default_value "false"
 
 $gdk_home = "$exampleproject_home\Game\Plugins\UnrealGDK"
-$game_project = "$exampleproject_home/Game/GDKShooter.uproject"
+$game_project = "$exampleproject_home\Game\GDKShooter.uproject"
 
 pushd "$exampleproject_home"
     Start-Event "clone-gdk-plugin" "prep-editor"
@@ -85,7 +85,7 @@ pushd "$exampleproject_home"
 
     # Invoke the GDK commandlet to generate schema and snapshot. Note: this needs to be run prior to cooking 
     Start-Event "generate-schema" "prep-editor"
-        pushd "${unreal_engine_symlink_dir}/Engine/Binaries/Win64"
+        pushd "${unreal_engine_symlink_dir}\Engine\Binaries\Win64"
             $UE4Editor=((Convert-Path .) + "\UE4Editor-Cmd.exe")
             $schema_gen_proc = Start-Process -PassThru -NoNewWindow -FilePath $UE4Editor -ArgumentList @(`
                 "$game_project", `
@@ -121,8 +121,8 @@ pushd "$exampleproject_home"
         $zip_proc = Start-Process -Wait -PassThru -NoNewWindow "7z" -ArgumentList @(`
             "a", `
             "-mx3", `
-            "artifacts/Schema.zip", `
-            "$PSScriptRoot/../spatial/schema" `
+            "artifacts\Schema.zip", `
+            "$PSScriptRoot\..\spatial\schema" `
         )
         if ($zip_proc.ExitCode -ne 0) {
             Write-Log "Failed to zip schema. Error: $($zip_proc.ExitCode)"
@@ -133,8 +133,8 @@ pushd "$exampleproject_home"
         $zip_proc = Start-Process -Wait -PassThru -NoNewWindow "7z" -ArgumentList @(`
             "a", `
             "-mx3", `
-            "artifacts/Snapshots.zip", `
-            "$PSScriptRoot/../spatial/snapshots" `
+            "artifacts\Snapshots.zip", `
+            "$PSScriptRoot\..\spatial\snapshots" `
         )
 
         if ($zip_proc.ExitCode -ne 0) {

--- a/ci/setup-and-build.sh
+++ b/ci/setup-and-build.sh
@@ -115,7 +115,7 @@ pushd "$(dirname "$0")"
         buildkite-agent meta-data set "${ENGINE_COMMIT_FORMATTED_HASH}-build-ios-queue-id" "$BUILDKITE_AGENT_META_DATA_QUEUE"       
     fi
 
-    # zip up the built-out mac client
+    # Zip up the built-out mac client
     7z a -mx3 "${EXAMPLEPROJECT_HOME}/cooked-mac.zip" "${EXAMPLEPROJECT_HOME}/cooked-mac" 
     
     echo "--- build-ios-client"

--- a/ci/setup-and-build.sh
+++ b/ci/setup-and-build.sh
@@ -18,7 +18,6 @@ run_uat() {
     GAME_UPROJECT="${8:-}"
 
     ${ENGINE_DIRECTORY}/Engine/Build/BatchFiles/RunUAT.sh \
-        -ScriptsForProject="${GAME_UPROJECT}" \
         BuildCookRun \
         -nocompileeditor \
         -nop4 \
@@ -29,10 +28,10 @@ run_uat() {
         -archivedirectory="${ARCHIVE_DIRECTORY}" \
         -package \
         -clientconfig="${CLIENT_CONFIG}" \
-        -ue4exe="${EXAMPLEPROJECT_HOME}/UnrealEngine/Engine/Binaries/Mac/UE4Editor-Cmd" \
-        -pak \
-        -prereqs \
-        -nodebuginfo \
+        -noserver \
+        -unattended \
+        -CrashForUAT \
+        -SkipCookingEditorContent \
         -targetplatform="${TARGET_PLATFORM}" \
         -build \
         -utf8output \
@@ -57,6 +56,10 @@ pushd "$(dirname "$0")"
             --single-branch \
             --depth 1
     popd
+
+    # Grab Artifacts
+    mkdir -p "${EXAMPLEPROJECT_HOME}/Game/Content/Spatial/"
+    buildkite-agent artifact download "*SchemaDatabase.uasset" "${EXAMPLEPROJECT_HOME}"
 
     echo "--- print-head-gdk-commit"
     pushd "${GDK_HOME}"
@@ -90,23 +93,6 @@ pushd "$(dirname "$0")"
             Mac \
             Development \
             "${GAME_UPROJECT}"
-
-        echo "--- generate-schema"
-        pushd "Engine/Binaries/Mac"
-            UE4Editor.app/Contents/MacOS/UE4Editor \
-                "${GAME_UPROJECT}" \
-                -run=CookAndGenerateSchema \
-                -targetplatform=MacNoEditor \
-                -SkipShaderCompile \
-                -unversioned \
-                -map="/Maps/$MAIN_MAP_NAME"
-
-            UE4Editor.app/Contents/MacOS/UE4Editor \
-                "${GAME_UPROJECT}" \
-                -run=GenerateSchemaAndSnapshots \
-                -MapPaths="/Maps/$MAIN_MAP_NAME" \
-                -SkipSchema
-        popd
     popd
 
     echo "--- build-mac-client"
@@ -115,8 +101,8 @@ pushd "$(dirname "$0")"
         "${EXAMPLEPROJECT_HOME}" \
         "Development" \
         "Mac" \
-        "${EXAMPLEPROJECT_HOME}/cooked-mac-${ENGINE_COMMIT_FORMATTED_HASH}" \
-        "-iterative" \
+        "${EXAMPLEPROJECT_HOME}/cooked-mac" \
+        "" \
         "" \
         "${GAME_UPROJECT}"
     
@@ -129,6 +115,9 @@ pushd "$(dirname "$0")"
         buildkite-agent meta-data set "${ENGINE_COMMIT_FORMATTED_HASH}-build-ios-queue-id" "$BUILDKITE_AGENT_META_DATA_QUEUE"       
     fi
 
+    # zip up the built-out mac client
+    7z a -mx3 "${EXAMPLEPROJECT_HOME}/cooked-mac.zip" "${EXAMPLEPROJECT_HOME}/cooked-mac" 
+    
     echo "--- build-ios-client"
     AUTH_TOKEN=$(buildkite-agent meta-data get "auth-token")
     DEPLOYMENT_NAME=$(buildkite-agent meta-data get "deployment-name-${STEP_NUMBER}")


### PR DESCRIPTION
Moved the schema and snapshot generation into a separate step. This allows the mac agent to pull the correct schema database from the artifacts and the iOS firebase test will be able to connect to the deployment without any errors about wrong schema appearing. 

also fixed up some smaller things like zipping up the mac client before adding it to the artifacts and enabling normalised upload paths to avoid conflicts when pulling artifacts onto different agents

example build that passed: https://buildkite.com/improbable/unrealgdkexampleproject-nightly/builds/3168#_