### PR TITLE
Update runtime version to 15 preview-4 for nightly build

### DIFF
--- a/.buildkite/nightly.steps.yaml
+++ b/.buildkite/nightly.steps.yaml
@@ -37,7 +37,7 @@ env:
     GDK_REPOSITORY: "git@github.com:spatialos/UnrealGDK.git"
     MAIN_MAP_NAME: "Control_Small"
     SPATIAL_PROJECT_NAME: "unreal_gdk"
-    SPATIAL_RUNTIME_VERSION: "0.4.3" ## the runtime version of SpatialOS
+    SPATIAL_RUNTIME_VERSION: "15.0.0-preview-4" ## the runtime version of SpatialOS
 
 steps:
   - label: "generate-pipeline-steps"


### PR DESCRIPTION
The firebase has broken by a connection issue caused by the current UnrealGDK version that couldn't connect to 0.4.3 of squid.
We need to update the configuration of the nightly build.

Successful build:https://buildkite.com/improbable/unrealgdkexampleproject-nightly/builds/3755#9f684b9e-cce9-43c2-9f37-82f8d8bb56f6
Successful build without firebase:https://buildkite.com/improbable/unrealgdkexampleproject-nightly/builds/3754