### PR TITLE
Specify iOS device and version for firebase tests

### DIFF
--- a/ci/run-firebase-test.py
+++ b/ci/run-firebase-test.py
@@ -63,6 +63,12 @@ def gcloud_upload(app_platform, app_path, gcloud_storage_keyword, success_keywor
         '--scenario-numbers 1',
         '--format="json"',
     ]
+
+    if app_platform == 'ios':
+        ios_device = common.get_environment_variable(
+        'IOS_DEVICE_AND_VERSION', 'model=iphonexs,version=12.0')
+        cmds.append('--device ' + ios_device)
+
     res = common.run_shell(cmds)
     gcloud_storage_url = ''
     for line in res.stderr.readlines():
@@ -131,7 +137,7 @@ if __name__ == "__main__":
     res = common.run_shell(cmds)
     project = res.stdout.read().decode('UTF-8')
 
-    # Makre sure FIREBASE_LOG_DIR is exist
+    # Make sure FIREBASE_LOG_DIR is exist
     if os.path.exists(FIREBASE_LOG_DIR):
         os.mkdir(FIREBASE_LOG_DIR)
         


### PR DESCRIPTION
exposing a new env variable that you can use to specify which device and version you want to use. Changing the default to iPhoneXS 12.0 as the current firebase default seems to be deprecated and therefore our CI has been failing.

passing build: https://buildkite.com/improbable/unrealgdkexampleproject-nightly/builds/3866