### PR TITLE
[UNR-4369] Disable FastBuild in CI

### DIFF
--- a/ci/nightly.gen.auth.token.yaml
+++ b/ci/nightly.gen.auth.token.yaml
@@ -53,7 +53,7 @@ steps:
       - "artifacts/Snapshots.zip"
     env:
       GDK_BRANCH: "${GDK_BRANCH}"
-      UE-SharedDataCachePath: "\\\\gdk-for-unreal-cache.${CI_ENVIRONMENT}-intinf-eu1.i8e.io\\samba\\ddc"
+      # UE-SharedDataCachePath: "\\\\gdk-for-unreal-cache.${CI_ENVIRONMENT}-intinf-eu1.i8e.io\\samba\\ddc" # TODO: UNR-4369 - Temporarily disabled until DDC issues are resolved.
       FASTBUILD_CACHE_PATH: "\\\\gdk-for-unreal-cache.${CI_ENVIRONMENT}-intinf-eu1.i8e.io\\samba\\fastbuild"
       FASTBUILD_CACHE_MODE: rw
       # FASTBUILD_BROKERAGE_PATH: "\\\\fastbuild-brokerage.${CI_ENVIRONMENT}-intinf-eu1.i8e.io\\samba" TODO: UNR-3208 - Temporarily disabled until distribution issues resolved.

--- a/ci/nightly.gen.auth.token.yaml
+++ b/ci/nightly.gen.auth.token.yaml
@@ -57,3 +57,4 @@ steps:
       FASTBUILD_CACHE_PATH: "\\\\gdk-for-unreal-cache.${CI_ENVIRONMENT}-intinf-eu1.i8e.io\\samba\\fastbuild"
       FASTBUILD_CACHE_MODE: rw
       # FASTBUILD_BROKERAGE_PATH: "\\\\fastbuild-brokerage.${CI_ENVIRONMENT}-intinf-eu1.i8e.io\\samba" TODO: UNR-3208 - Temporarily disabled until distribution issues resolved.
+      DISABLE_FASTBUILD: true # TODO: UNR-4369 - Temporarily disabled until FastBuild cache issues are resolved.


### PR DESCRIPTION
Disable FastBuild in CI due to issues with the cache causing builds to timeout.