### PR TITLE
Disable Magic Leap plugins that were triggering WARNs

### DIFF
--- a/Game/GDKShooter.uproject
+++ b/Game/GDKShooter.uproject
@@ -25,6 +25,33 @@
 		{
 			"Name": "SpatialGDK",
 			"Enabled": true
+		},
+		{
+			"Name": "MagicLeapMedia",
+			"Enabled": false,
+			"SupportedTargetPlatforms": [
+				"Lumin"
+			]
+		},
+		{
+			"Name": "MagicLeap",
+			"Enabled": false,
+			"SupportedTargetPlatforms": [
+				"Lumin",
+				"Mac",
+				"Win64"
+			]
+		},
+		{
+			"Name": "LuminPlatformFeatures",
+			"Enabled": false,
+			"SupportedTargetPlatforms": [
+				"Lumin"
+			]
+		},
+		{
+			"Name": "MLSDK",
+			"Enabled": false
 		}
 	]
 }


### PR DESCRIPTION
* I made these changes via the **Edit** > **Plugins** flow. I didn't manually edit the `.uproject` file.
* These changes non-destructively disable Magic Leap.
* They stop these errors triggering when you open the project or generate schema:
`Warning: MLSDK not found.  This likely means the MLSDK environment variable is not set.`
`Warning: VR disabled because ZI is not enabled.`
* I tested this before and after the change.