### PR TITLE
Fix "The config file will be staged, but is not whitelisted or blacklisted" WARNs

### DIFF
--- a/Game/Config/DefaultGame.ini
+++ b/Game/Config/DefaultGame.ini
@@ -20,4 +20,3 @@ MaxSpectators=100
 +WhitelistConfigFiles=GDKShooter/Config/DefaultSpatialGDKEditorSettings.ini
 +WhitelistConfigFiles=GDKShooter/Config/DefaultSpatialGDKSettings.ini
 +WhitelistConfigFiles=Engine/Config/DefaultSpatialGDKSettings.ini
-+WhitelistConfigFiles=GDKShooter/Config/DefaultSpatialGDKSettings.ini

--- a/Game/Config/DefaultGame.ini
+++ b/Game/Config/DefaultGame.ini
@@ -20,5 +20,4 @@ MaxSpectators=100
 +WhitelistConfigFiles=GDKShooter/Config/DefaultSpatialGDKEditorSettings.ini
 +WhitelistConfigFiles=GDKShooter/Config/DefaultSpatialGDKSettings.ini
 +WhitelistConfigFiles=Engine/Config/DefaultSpatialGDKSettings.ini
-+WhitelistConfigFiles=GDKShooter/Config/DefaultSpatialGDKEditorSettings.ini
 +WhitelistConfigFiles=GDKShooter/Config/DefaultSpatialGDKSettings.ini

--- a/Game/Config/DefaultGame.ini
+++ b/Game/Config/DefaultGame.ini
@@ -15,3 +15,10 @@ MaxSpectators=100
 +MapsToCook=(FilePath="/Game/Maps/Control_Medium")
 +MapsToCook=(FilePath="/Game/Maps/Control_Small")
 +DirectoriesToAlwaysCook=(Path="/Game/Spatial")
+
+[Staging]
++WhitelistConfigFiles=GDKShooter/Config/DefaultSpatialGDKEditorSettings.ini
++WhitelistConfigFiles=GDKShooter/Config/DefaultSpatialGDKSettings.ini
++WhitelistConfigFiles=Engine/Config/DefaultSpatialGDKSettings.ini
++WhitelistConfigFiles=GDKShooter/Config/DefaultSpatialGDKEditorSettings.ini
++WhitelistConfigFiles=GDKShooter/Config/DefaultSpatialGDKSettings.ini


### PR DESCRIPTION
#### Description
Modified `DefaultGame.ini` to whitelist files that were previously throwing WARNs when building assemblies for cloud deployments.

#### Release note
https://github.com/spatialos/UnrealGDK/pull/3008

#### Tests
* I cloud deployed after I implemented this fix in order to ensure that I hadn't broken that functionality.
* I confirmed that the WARNs are gone.

#### Documentation
Not needed.

#### Primary reviewers
@mironec