### PR TITLE
Fix labels and messages. Make new ci required.

### DIFF
--- a/.buildkite/nightly.steps.yaml
+++ b/.buildkite/nightly.steps.yaml
@@ -43,9 +43,10 @@ steps:
   # New build pipeline
   # Trigger a 4.26 build
   - trigger: "unrealgdkbuild-ci"
-    label: "gdk-ci-426 ${BUILDKITE_MESSAGE}"
-    async: true
-    build: 
+    label: "exampleproject-ci"
+    async: false
+    build:
+      message: "exampleproject-4.26 ${BUILDKITE_MESSAGE}"
       env: 
         BUILD_TYPE: "EXAMPLE"
         GDK_BRANCH: "master"

--- a/.buildkite/nightly.steps.yaml
+++ b/.buildkite/nightly.steps.yaml
@@ -1,4 +1,5 @@
 ---
+ci_version: &ci_version "1.0"
 # This is designed to trap and retry failures because agent lost
 # connection. Agent exits with -1 in this case.
 agent_transients: &agent_transients
@@ -46,6 +47,7 @@ steps:
     label: "exampleproject-ci"
     async: false
     build:
+      branch: *ci_version
       message: "exampleproject-4.26 ${BUILDKITE_MESSAGE}"
       env: 
         BUILD_TYPE: "EXAMPLE"


### PR DESCRIPTION
Labels are used to identify which builds are required by GH. By generating unique labels for each branch we were spamming our GH UI with new builds to watch and also made it impossible to make the old-ci non-required without removing it. This fixes that. 