### PR TITLE
Lock mouse on UI open

### DIFF
--- a/Game/Source/GDKShooter/Private/Controllers/GDKPlayerController.cpp
+++ b/Game/Source/GDKShooter/Private/Controllers/GDKPlayerController.cpp
@@ -115,7 +115,9 @@ void AGDKPlayerController::SetUIMode(bool bIsUIMode)
 
 	if (bIsUIMode)
 	{
-		SetInputMode(FInputModeGameAndUI());
+		FInputModeGameAndUI Mode;
+		Mode.SetLockMouseToViewportBehavior(EMouseLockMode::LockAlways);
+		SetInputMode(Mode);
 		ActivateTouchInterface(nullptr);
 	}
 	else


### PR DESCRIPTION
We call AGDKPlayerController::SetUIMode when we bring up UI. It already configures how we want input to be handled. I just made it also lock the mouse to the window. Easy to exit out of this lock though.